### PR TITLE
Enable frozen_string_literal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /db
 /hoge.rb
+/.bundle/
 /.idea/
 /coverage/
 /vendor/

--- a/lib/injector.rb
+++ b/lib/injector.rb
@@ -20,9 +20,9 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
+# frozen_string_literal: true
 require 'yaml'
 
-# frozen_string_literal: true
 module Injector
   def self.extended(obj)
     obj.class_eval do


### PR DESCRIPTION
Fix a following warning and enable frozen_string_literal:

```sh
$ find . | grep -e '\.rb$' | xargs ruby -w
./lib/injector.rb:25: warning: `frozen_string_literal' is ignored after any tokens
```