### PR TITLE
Support HipChat's privmsg for alerting by ikachan

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,8 @@ LINE uses the Ikasan tool to send HipChat messages over HTTP. This tool is usefu
 
 Specify the Ikachan(not Ikasan) module and the URL if you want to receive alert notifications through HipChat.
 
+If you want to use `/privmsg` API endpoint, please set the environment variable `HIPCHAT_PRIVMSG` (`/privmsg` endpoint can fire the mentioned message like `Alert: @you`).
+
 * Mail
 
 Specify the MailNotify module and the SMPT server if you want to receive alert notifications through email.

--- a/lib/promgen/alert/sender/ikachan.rb
+++ b/lib/promgen/alert/sender/ikachan.rb
@@ -28,7 +28,7 @@ class Promgen
     class Sender
       class Ikachan
         def initialize(url:, logger:, project_repo:)
-          @url = url.gsub(%r{/$}, '') + '/notice'
+          @url = url.gsub(%r{/$}, '') + '/' + (ENV['HIPCHAT_PRIVMSG'] ? 'privmsg' : 'notice')
           @logger = logger
           @project_repo = project_repo
         end


### PR DESCRIPTION
Problem
--

In case of alerting uses ikachan with HipChat through `/notice` API endpoint, it cannot fire the mentioned message to user(s) (e.g. `Alert: @here`).

Way to solve
--

Support to switch the API endpoint through the environment variable `HIPCHAT_PRIVMSG`.
If `HIPCHAT_PRIVMSG` is set, promgen alerting uses `/privmsg` endpoint of ikachan. `/privmsg` endpoint can fire the mentioned message.