### PR TITLE
Set default exporter list from config

### DIFF
--- a/config.sample.yml
+++ b/config.sample.yml
@@ -17,3 +17,7 @@ alert_senders:
   - module: Webhook
   - module: Alerta
     alerta_url: http://alerta.localhost
+# Default Exporter Settings
+default_exporters:
+    node: 9100
+    nginx: 9113

--- a/config.sample.yml
+++ b/config.sample.yml
@@ -21,7 +21,7 @@ password: foobar
 # Default Exporter Settings
 # Examples from https://github.com/prometheus/prometheus/wiki/Default-port-allocations
 default_exporters:
-    node: 9100
-    nginx: 9113
-    mysqld: 9104
-    apache: 9117
+  node: 9100
+  nginx: 9113
+  mysqld: 9104
+  apache: 9117

--- a/config.sample.yml
+++ b/config.sample.yml
@@ -17,7 +17,11 @@ alert_senders:
   - module: Webhook
   - module: Alerta
     alerta_url: http://alerta.localhost
+
 # Default Exporter Settings
+# Examples from https://github.com/prometheus/prometheus/wiki/Default-port-allocations
 default_exporters:
     node: 9100
     nginx: 9113
+    mysqld: 9104
+    apache: 9117

--- a/lib/promgen/web.rb
+++ b/lib/promgen/web.rb
@@ -52,7 +52,8 @@ class Promgen
         alert_senders:,
         server_directory_service:,
         logger:,
-        service_service:
+        service_service:,
+        config:
     )
       super()
       @farm_service = farm_service
@@ -68,6 +69,7 @@ class Promgen
       @server_directory_service = server_directory_service
       @logger = logger
       @service_service = service_service
+      @default_exporters = config['default_exporters']
     end
 
     set :erb, escape_html: true

--- a/lib/promgen/web.rb
+++ b/lib/promgen/web.rb
@@ -69,7 +69,8 @@ class Promgen
       @server_directory_service = server_directory_service
       @logger = logger
       @service_service = service_service
-      @default_exporters = config['default_exporters']
+
+      @default_exporters = config.fetch('default_exporters', {:node => 9100, :nginx => 9113})
     end
 
     set :erb, escape_html: true

--- a/lib/promgen/web/route/project_exporter_route.rb
+++ b/lib/promgen/web/route/project_exporter_route.rb
@@ -27,10 +27,6 @@ require 'sinatra/json'
 class Promgen
   class Web < Sinatra::Base
     get '/project/:project_id/exporter/register' do
-      @default_exporters = {
-        :node => 9100,
-        :nginx => 9113,
-      }
       erb :register_project_exporter
     end
 

--- a/lib/promgen/web/route/project_exporter_route.rb
+++ b/lib/promgen/web/route/project_exporter_route.rb
@@ -27,6 +27,10 @@ require 'sinatra/json'
 class Promgen
   class Web < Sinatra::Base
     get '/project/:project_id/exporter/register' do
+      @default_exporters = {
+        :node => 9100,
+        :nginx => 9113,
+      }
       erb :register_project_exporter
     end
 

--- a/views/register_project_exporter.erb
+++ b/views/register_project_exporter.erb
@@ -9,27 +9,29 @@
 </div>
 
 <div class="row">
+  <div class="col-md-8">
+    <form method="post" action="<%= to("/project/#{@project.id}/exporter/register") %>">
+      <div class="form-group">
+        <label for="inputPort">Port</label>
+        <input type="text" name="port" class="form-control" id="inputPort" pattern="[0-9]+" required>
+      </div>
+      <div class="form-group">
+        <label for="inputJob">Job</label>
+        <input type="text" name="job" class="form-control" id="inputJob" required>
+        <p class="help-block">nginx, apache, mysqld, node etc.</p>
+      </div>
+      <button type="submit" class="btn btn-default">Register</button>
+    </form>
+  </div>
+
+  <div class="col-md-4">
+    <p>Common Exporters</p>
   <% @default_exporters.each do |job, port| %>
-      <form method="post" action="<%= to("/project/#{@project.id}/exporter/register") %>" style="display: inline">
-        <input type="hidden" name="job" value="<%= job %>">
-        <input type="hidden" name="port" value="<%= port %>">
-        <button type="submit" class="btn btn-primary">Register <%= job %>_exporter(Port: <%= port %>)</button>
-      </form>
+    <form method="post" action="<%= to("/project/#{@project.id}/exporter/register") %>" style="display: inline">
+      <input type="hidden" name="job" value="<%= job %>">
+      <input type="hidden" name="port" value="<%= port %>">
+      <button type="submit" class="btn btn-primary">Register <%= job %>_exporter(Port: <%= port %>)</button>
+    </form>
   <% end %>
-
-  <hr>
-
-  <form method="post" action="<%= to("/project/#{@project.id}/exporter/register") %>">
-    <div class="form-group">
-      <label for="inputPort">Port</label>
-      <input type="text" name="port" class="form-control" id="inputPort" pattern="[0-9]+" required>
-    </div>
-    <div class="form-group">
-      <label for="inputJob">Job</label>
-      <input type="text" name="job" class="form-control" id="inputJob" required>
-      <p class="help-block">nginx, apache, mysqld, node etc.</p>
-    </div>
-
-    <button type="submit" class="btn btn-default">Register</button>
-  </form>
+  </div>
 </div>

--- a/views/register_project_exporter.erb
+++ b/views/register_project_exporter.erb
@@ -9,11 +9,11 @@
 </div>
 
 <div class="row">
-  <% [{job: 'node', port: 9100}, {job: 'nginx', port: 9113}].each do |e| %>
+  <% @default_exporters.each do |job, port| %>
       <form method="post" action="<%= to("/project/#{@project.id}/exporter/register") %>" style="display: inline">
-        <input type="hidden" name="job" value="<%= e[:job] %>">
-        <input type="hidden" name="port" value="<%= e[:port] %>">
-        <button type="submit" class="btn btn-primary">Register <%= e[:job] %>_exporter(Port: <%= e[:port] %>)</button>
+        <input type="hidden" name="job" value="<%= job %>">
+        <input type="hidden" name="port" value="<%= port %>">
+        <button type="submit" class="btn btn-primary">Register <%= job %>_exporter(Port: <%= port %>)</button>
       </form>
   <% end %>
 


### PR DESCRIPTION
This allows a team to set the commonly used exporters in the config file.

```yml
default_exporters:
    node: 9100
    nginx: 9113
    mysqld: 9104
    apache: 9117
```

![2016-08-25 12 38 30](https://cloud.githubusercontent.com/assets/89725/17955981/1f280dec-6ac1-11e6-890f-0dab07eb1448.png)