### PR TITLE
Metrics stub to allow Prometheus to check up/down status

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -13,6 +13,8 @@ app = Promgen.build
 use Rack::Static, urls: ['/css'], root: File.join(File.dirname(__FILE__), 'public')
 
 run Rack::URLMap.new(
+  # /metrics stub to allow prometheus to check 'up' status
+  '/metrics' => lambda { |env| [200, {'Content-Type' => 'text/plain'}, ['']] },
   '/alert/' => Rack::Auth::Basic.new(app.alert) do |username, password|
     username == 'promgen' && password == app.config['password']
   end,

--- a/config.ru
+++ b/config.ru
@@ -14,7 +14,7 @@ use Rack::Static, urls: ['/css'], root: File.join(File.dirname(__FILE__), 'publi
 
 run Rack::URLMap.new(
   # /metrics stub to allow prometheus to check 'up' status
-  '/metrics' => lambda { |env| [200, {'Content-Type' => 'text/plain'}, ['']] },
+  '/metrics' => proc { [200, { 'Content-Type' => 'text/plain' }, ['']] },
   '/alert/' => Rack::Auth::Basic.new(app.alert) do |username, password|
     username == 'promgen' && password == app.config['password']
   end,


### PR DESCRIPTION
Later I would like to implement some promgen specific metrics (particularly on Alert::Sender delivery) but in the mean time, I thought it would be good to have an empty /metrics route so that I could take advantage of Prometheus and a basic InstanceDown rule to ensure that Promgen is running