### PR TITLE
Audit log page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem 'mysql', require: false
 gem 'chronic_duration'
 gem 'mail'
 gem 'unicorn'
+gem 'will_paginate', '~> 3.0.5'
 
 group :test do
   gem 'rake'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,6 +72,7 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff
+    will_paginate (3.0.7)
 
 PLATFORMS
   ruby
@@ -92,6 +93,7 @@ DEPENDENCIES
   test-unit
   unicorn
   webmock
+  will_paginate (~> 3.0.5)
 
 BUNDLED WITH
-   1.12.4
+   1.12.5

--- a/lib/promgen.rb
+++ b/lib/promgen.rb
@@ -41,7 +41,9 @@ require 'promgen/repo/project_repo'
 require 'promgen/repo/service_repo'
 require 'promgen/repo/project_farm_repo'
 require 'promgen/repo/server_directory_repo'
+require 'promgen/repo/audit_repo'
 
+require 'promgen/service/audit_service'
 require 'promgen/service/farm_service'
 require 'promgen/service/host_service'
 require 'promgen/service/project_exporter_service'
@@ -79,6 +81,7 @@ class Promgen
   register :project_repo,         Promgen::Repo::ProjectRepo
   register :project_farm_repo,    Promgen::Repo::ProjectFarmRepo
   register :server_directory_repo, Promgen::Repo::ServerDirectoryRepo
+  register :audit_log_repo, Promgen::Repo::AuditRepo
 
   register :farm_service, Promgen::Service::FarmService
   register :host_service, Promgen::Service::HostService
@@ -88,6 +91,7 @@ class Promgen
   register :rule_service, Promgen::Service::RuleService
   register :server_directory_service, Promgen::Service::ServerDirectoryService
   register :service_service, Promgen::Service::ServiceService
+  register :audit_log_service, Promgen::Service::AuditService
 
   register :web,                  Promgen::Web
   register :config_writer,        Promgen::ConfigWriter

--- a/lib/promgen/repo/audit_repo.rb
+++ b/lib/promgen/repo/audit_repo.rb
@@ -1,0 +1,51 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2016 LINE Corporation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+# frozen_string_literal: true
+# configuration for prometheus
+
+class Promgen
+  class Repo
+    class AuditRepo
+      def initialize(logger:, db:)
+        raise ArgumentError, 'DB must not be null' if db.nil?
+        @logger = logger
+        @db = db
+      end
+
+      def log(entry:)
+        raise ArgumentError, 'entry must not be null' if entry.nil?
+
+        @db[:audit_log].insert(
+          entry: entry
+        )
+      end
+
+      def all
+        @db[:rule].order(:id).map do |e|
+          e
+          #Promgen::Rule.new(e)
+        end
+      end
+    end
+  end
+end

--- a/lib/promgen/repo/audit_repo.rb
+++ b/lib/promgen/repo/audit_repo.rb
@@ -23,6 +23,9 @@
 # frozen_string_literal: true
 # configuration for prometheus
 
+require 'will_paginate'
+require 'will_paginate/sequel'
+
 class Promgen
   class Repo
     class AuditRepo
@@ -47,10 +50,8 @@ class Promgen
         end
       end
 
-      def last(limit = 20)
-        @db[:audit_log].order(Sequel.desc(:id)).limit(limit).map do |entry|
-          entry
-        end
+      def paginate(page:, per_page:)
+        @db[:audit_log].order(Sequel.desc(:id)).extension(:pagination).paginate(page.to_i, per_page.to_i)
       end
     end
   end

--- a/lib/promgen/repo/audit_repo.rb
+++ b/lib/promgen/repo/audit_repo.rb
@@ -47,7 +47,7 @@ class Promgen
         end
       end
 
-      def last(limit=20)
+      def last(limit = 20)
         @db[:audit_log].order(Sequel.desc(:id)).limit(limit).map do |entry|
           entry
         end

--- a/lib/promgen/repo/audit_repo.rb
+++ b/lib/promgen/repo/audit_repo.rb
@@ -36,14 +36,14 @@ class Promgen
         raise ArgumentError, 'entry must not be null' if entry.nil?
 
         @db[:audit_log].insert(
-          entry: entry
+          entry: entry,
+          timestamp: Time.now.getutc.to_i
         )
       end
 
       def all
-        @db[:rule].order(:id).map do |e|
-          e
-          #Promgen::Rule.new(e)
+        @db[:audit_log].order(:id).map do |entry|
+          entry
         end
       end
     end

--- a/lib/promgen/repo/audit_repo.rb
+++ b/lib/promgen/repo/audit_repo.rb
@@ -42,7 +42,13 @@ class Promgen
       end
 
       def all
-        @db[:audit_log].order(:id).map do |entry|
+        @db[:audit_log].order(Sequel.desc(:id)).map do |entry|
+          entry
+        end
+      end
+
+      def last(limit=20)
+        @db[:audit_log].order(Sequel.desc(:id)).limit(limit).map do |entry|
           entry
         end
       end

--- a/lib/promgen/service/audit_service.rb
+++ b/lib/promgen/service/audit_service.rb
@@ -1,0 +1,39 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2016 LINE Corporation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+
+require 'forwardable'
+
+class Promgen
+  class Service
+    class AuditService
+      extend Forwardable
+
+      def initialize(logger:, audit_log_repo:)
+        @logger = logger
+        @audit_log_repo = audit_log_repo
+      end
+
+      def_delegators :@audit_log_repo, :all
+    end
+  end
+end

--- a/lib/promgen/service/audit_service.rb
+++ b/lib/promgen/service/audit_service.rb
@@ -20,7 +20,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-
 require 'forwardable'
 
 class Promgen

--- a/lib/promgen/service/audit_service.rb
+++ b/lib/promgen/service/audit_service.rb
@@ -33,7 +33,7 @@ class Promgen
         @audit_log_repo = audit_log_repo
       end
 
-      def_delegators :@audit_log_repo, :log, :all
+      def_delegators :@audit_log_repo, :log, :all, :last
     end
   end
 end

--- a/lib/promgen/service/audit_service.rb
+++ b/lib/promgen/service/audit_service.rb
@@ -33,7 +33,7 @@ class Promgen
         @audit_log_repo = audit_log_repo
       end
 
-      def_delegators :@audit_log_repo, :all
+      def_delegators :@audit_log_repo, :log, :all
     end
   end
 end

--- a/lib/promgen/service/audit_service.rb
+++ b/lib/promgen/service/audit_service.rb
@@ -32,7 +32,7 @@ class Promgen
         @audit_log_repo = audit_log_repo
       end
 
-      def_delegators :@audit_log_repo, :log, :all, :last
+      def_delegators :@audit_log_repo, :log, :all, :paginate
     end
   end
 end

--- a/lib/promgen/web.rb
+++ b/lib/promgen/web.rb
@@ -33,6 +33,7 @@ require 'promgen/web/route/host_route'
 require 'promgen/web/route/service_route'
 require 'promgen/web/route/project_exporter_route'
 require 'promgen/web/route/rule_route'
+require 'promgen/web/route/audit_route'
 
 require 'erubis'
 require 'tilt/erubis'
@@ -53,6 +54,8 @@ class Promgen
         server_directory_service:,
         logger:,
         service_service:,
+        audit_log_service:,
+
         config:
     )
       super()
@@ -69,6 +72,7 @@ class Promgen
       @server_directory_service = server_directory_service
       @logger = logger
       @service_service = service_service
+      @audit_log_service = audit_log_service
 
       @default_exporters = config.fetch('default_exporters', node: 9100, nginx: 9113)
     end

--- a/lib/promgen/web/route/audit_route.rb
+++ b/lib/promgen/web/route/audit_route.rb
@@ -27,7 +27,7 @@ require 'promgen/service/audit_service'
 class Promgen
   class Web < Sinatra::Base
     get '/log' do
-      @logs = @audit_log_service.all
+      @logs = @audit_log_service.last 50
       erb :audit_log
     end
   end

--- a/lib/promgen/web/route/audit_route.rb
+++ b/lib/promgen/web/route/audit_route.rb
@@ -22,12 +22,16 @@
 
 # frozen_string_literal: true
 require 'sinatra/base'
+require 'will_paginate'
 require 'promgen/service/audit_service'
+
 
 class Promgen
   class Web < Sinatra::Base
+    include WillPaginate::Sinatra::Helpers
+
     get '/log' do
-      @logs = @audit_log_service.last 50
+      @logs = @audit_log_service.paginate(:page => params[:page] ||= 1, :per_page => 20)
       erb :audit_log
     end
   end

--- a/lib/promgen/web/route/audit_route.rb
+++ b/lib/promgen/web/route/audit_route.rb
@@ -1,0 +1,34 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2016 LINE Corporation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+# frozen_string_literal: true
+require 'sinatra/base'
+require 'promgen/service/audit_service'
+
+class Promgen
+  class Web < Sinatra::Base
+    get '/log' do
+      @logs = @audit_log_service.all
+      erb :audit_log
+    end
+  end
+end

--- a/lib/promgen/web/route/audit_route.rb
+++ b/lib/promgen/web/route/audit_route.rb
@@ -25,13 +25,12 @@ require 'sinatra/base'
 require 'will_paginate'
 require 'promgen/service/audit_service'
 
-
 class Promgen
   class Web < Sinatra::Base
     include WillPaginate::Sinatra::Helpers
 
     get '/log' do
-      @logs = @audit_log_service.paginate(:page => params[:page] ||= 1, :per_page => 20)
+      @logs = @audit_log_service.paginate(page: params[:page] ||= 1, per_page: 20)
       erb :audit_log
     end
   end

--- a/lib/promgen/web/route/project_exporter_route.rb
+++ b/lib/promgen/web/route/project_exporter_route.rb
@@ -35,7 +35,11 @@ class Promgen
       job = params['job']
 
       @project_exporter_service.register(project_id: @project.id, port: port, job: job)
-      @audit_log_service.log(entry: "Registered exporter #{job}:#{port} to #{@project.id}")
+
+      @project = @project_service.find(id: @project.id)
+      @service = @service_service.find(id: @project.service_id)
+      @audit_log_service.log(entry: "Registered exporter #{job}:#{port} to #{@service.name}:#{@project.name}")
+
       @config_writer.write
 
       redirect "/project/#{@project.id}"
@@ -45,7 +49,11 @@ class Promgen
       port = params['port']
 
       @project_exporter_service.delete(project_id: @project.id, port: port)
-      @audit_log_service.log(entry: "Removed exporter #{job}:#{port} from #{@project.id}")
+
+      @project = @project_service.find(id: @project.id)
+      @service = @service_service.find(id: @project.service_id)
+      @audit_log_service.log(entry: "Removed exporter #{port} from #{@service.name}:#{@project.name}")
+
       @config_writer.write
 
       redirect "/project/#{@project.id}"

--- a/lib/promgen/web/route/project_exporter_route.rb
+++ b/lib/promgen/web/route/project_exporter_route.rb
@@ -38,7 +38,7 @@ class Promgen
 
       @project = @project_service.find(id: @project.id)
       @service = @service_service.find(id: @project.service_id)
-      @audit_log_service.log(entry: "Registered exporter #{job}:#{port} to #{@service.name}:#{@project.name}")
+      @audit_log_service.log(entry: "Registered exporter #{job}:#{port} to Service:#{@service.name}/Project:#{@project.name}")
 
       @config_writer.write
 
@@ -52,7 +52,7 @@ class Promgen
 
       @project = @project_service.find(id: @project.id)
       @service = @service_service.find(id: @project.service_id)
-      @audit_log_service.log(entry: "Removed exporter #{port} from #{@service.name}:#{@project.name}")
+      @audit_log_service.log(entry: "Removed exporter #{port} from Service:#{@service.name}/Project:#{@project.name}")
 
       @config_writer.write
 

--- a/lib/promgen/web/route/project_exporter_route.rb
+++ b/lib/promgen/web/route/project_exporter_route.rb
@@ -35,6 +35,7 @@ class Promgen
       job = params['job']
 
       @project_exporter_service.register(project_id: @project.id, port: port, job: job)
+      @audit_log_service.log(entry: "Registered exporter #{job}:#{port} to #{@project.id}")
       @config_writer.write
 
       redirect "/project/#{@project.id}"
@@ -44,6 +45,7 @@ class Promgen
       port = params['port']
 
       @project_exporter_service.delete(project_id: @project.id, port: port)
+      @audit_log_service.log(entry: "Removed exporter #{job}:#{port} from #{@project.id}")
       @config_writer.write
 
       redirect "/project/#{@project.id}"

--- a/lib/promgen/web/route/project_route.rb
+++ b/lib/promgen/web/route/project_route.rb
@@ -51,7 +51,7 @@ class Promgen
         mail_address: empty_to_nil(params[:mail_address]),
         webhook_url: empty_to_nil(params[:webhook_url])
       )
-
+      @audit_log_service.log(entry: "Created project #{params[:name]}")
       redirect to('/service/' + params[:service_id])
     end
 
@@ -90,6 +90,7 @@ class Promgen
         webhook_url: empty_to_nil(params['webhook_url'])
       )
       @config_writer.write
+      @audit_log_service.log(entry: "Updated project #{params[:name]}")
       redirect "/project/#{@project.id}"
     end
 
@@ -113,6 +114,7 @@ class Promgen
         server_directory_id: params[:server_directory_id],
         farm_name: farm_name
       )
+      @audit_log_service.log(entry: "Linked project #{params[:name]} to farm #{params['farm_name']}")
       @config_writer.write
       redirect "/project/#{@project.id}"
     end
@@ -123,6 +125,7 @@ class Promgen
       halt 404, "Unknown project_farm_id: #{params[:project_farm_id]}" unless project_farm
 
       @project_farm_service.unlink(project_id: project_farm.project_id, farm_name: project_farm.farm_name)
+      @audit_log_service.log(entry: "Unlinked project #{params[:name]} from farm #{params['farm_name']}")
       @config_writer.write
 
       redirect "/project/#{project_farm.project_id}"

--- a/lib/promgen/web/route/project_route.rb
+++ b/lib/promgen/web/route/project_route.rb
@@ -53,7 +53,7 @@ class Promgen
       )
 
       @service = @service_service.find(id: params[:service_id])
-      @audit_log_service.log(entry: "Created project #{@service.name}:#{params[:name]}")
+      @audit_log_service.log(entry: "Created project #{params[:name]} under service #{@service.name}")
       redirect to('/service/' + params[:service_id])
     end
 

--- a/lib/promgen/web/route/project_route.rb
+++ b/lib/promgen/web/route/project_route.rb
@@ -51,7 +51,9 @@ class Promgen
         mail_address: empty_to_nil(params[:mail_address]),
         webhook_url: empty_to_nil(params[:webhook_url])
       )
-      @audit_log_service.log(entry: "Created project #{params[:name]}")
+
+      @service = @service_service.find(id: params[:service_id])
+      @audit_log_service.log(entry: "Created project #{@service.name}:#{params[:name]}")
       redirect to('/service/' + params[:service_id])
     end
 

--- a/lib/promgen/web/route/rule_route.rb
+++ b/lib/promgen/web/route/rule_route.rb
@@ -95,7 +95,7 @@ class Promgen
       @rule_writer.write
 
       @service = @service_service.find(id: params[:service_id])
-      @audit_log_service.log(entry: "Deleted rule for #{@service.name}")
+      @audit_log_service.log(entry: "Deleted rule for service #{@service.name}")
 
       redirect back
     end

--- a/lib/promgen/web/route/rule_route.rb
+++ b/lib/promgen/web/route/rule_route.rb
@@ -51,7 +51,7 @@ class Promgen
         @rule_writer.write
 
         @service = @service_service.find(id: params[:service_id])
-        @audit_log_service.log(entry: "Registered rules for #{@service.name}")
+        @audit_log_service.log(entry: "Registered rule #{alert_clause} for #{@service.name}")
 
         redirect "/service/#{params[:service_id]}/rule"
       end
@@ -81,7 +81,7 @@ class Promgen
         @rule_writer.write
 
         @service = @service_service.find(id: params[:service_id])
-        @audit_log_service.log(entry: "Updated rules for #{@service.name}")
+        @audit_log_service.log(entry: "Updated rule #{alert_clause} for #{@service.name}")
 
         redirect "/service/#{params[:service_id]}/rule"
       end

--- a/lib/promgen/web/route/rule_route.rb
+++ b/lib/promgen/web/route/rule_route.rb
@@ -50,6 +50,9 @@ class Promgen
         @rule_service.register(service_id: params[:service_id], alert_clause: alert_clause, if_clause: if_clause, for_clause: for_clause, labels_clause: labels_clause, annotations_clause: annotations_clause)
         @rule_writer.write
 
+        @service = @service_service.find(id: params[:service_id])
+        @audit_log_service.log(entry: "Registered rules for #{@service.name}")
+
         redirect "/service/#{params[:service_id]}/rule"
       end
     end
@@ -77,6 +80,9 @@ class Promgen
         @rule_service.update(id: rule.id, service_id: params[:service_id], alert_clause: alert_clause, if_clause: if_clause, for_clause: for_clause, labels_clause: labels_clause, annotations_clause: annotations_clause)
         @rule_writer.write
 
+        @service = @service_service.find(id: params[:service_id])
+        @audit_log_service.log(entry: "Updated rules for #{@service.name}")
+
         redirect "/service/#{params[:service_id]}/rule"
       end
     end
@@ -87,6 +93,9 @@ class Promgen
 
       @rule_service.delete(rule_id: rule_id)
       @rule_writer.write
+
+      @service = @service_service.find(id: params[:service_id])
+      @audit_log_service.log(entry: "Deleted rule for #{@service.name}")
 
       redirect back
     end

--- a/lib/promgen/web/route/service_route.rb
+++ b/lib/promgen/web/route/service_route.rb
@@ -50,6 +50,7 @@ class Promgen
 
     post '/service/register' do
       @service_service.insert(name: params[:name])
+      @audit_log_service.log(entry: "Created service #{params[:name]}")
       redirect '/service/'
     end
 
@@ -71,6 +72,7 @@ class Promgen
 
     post '/service/:service_id/delete' do
       @service_service.delete(id: params[:service_id])
+      @audit_log_service.log(entry: "Deleted service #{params[:service_id]}")
       redirect back
     end
 

--- a/lib/promgen/web/route/service_route.rb
+++ b/lib/promgen/web/route/service_route.rb
@@ -71,8 +71,9 @@ class Promgen
     end
 
     post '/service/:service_id/delete' do
+      @service = @service_service.find(id: params[:service_id])
       @service_service.delete(id: params[:service_id])
-      @audit_log_service.log(entry: "Deleted service #{params[:service_id]}")
+      @audit_log_service.log(entry: "Deleted service #{@service[:name]}")
       redirect back
     end
 

--- a/lib/promgen/web/route/service_route.rb
+++ b/lib/promgen/web/route/service_route.rb
@@ -71,9 +71,9 @@ class Promgen
     end
 
     post '/service/:service_id/delete' do
-      @service = @service_service.find(id: params[:service_id])
+      service = @service_service.find(id: params[:service_id])
       @service_service.delete(id: params[:service_id])
-      @audit_log_service.log(entry: "Deleted service #{@service[:name]}")
+      @audit_log_service.log(entry: "Deleted service #{service.name}")
       redirect back
     end
 

--- a/migrations/10_audit_log.rb
+++ b/migrations/10_audit_log.rb
@@ -1,0 +1,32 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2016 LINE Corporation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+Sequel.migration do
+  change do
+    create_table :audit_log do
+      primary_key :id
+
+      String :entry, null: false
+      String :timestamp, null: false
+    end
+  end
+end

--- a/migrations/10_audit_log.rb
+++ b/migrations/10_audit_log.rb
@@ -26,7 +26,7 @@ Sequel.migration do
       primary_key :id
 
       String :entry, null: false
-      String :timestamp, null: false
+      Integer :timestamp
     end
   end
 end

--- a/test/promgen/web/route/test_audit_log_route.rb
+++ b/test/promgen/web/route/test_audit_log_route.rb
@@ -1,0 +1,37 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2016 LINE Corporation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+# frozen_string_literal: true
+require 'promgen/test'
+
+class TestAuditLogRoute < Promgen::Test
+  include Rack::Test::Methods
+
+  def app
+    @app.web
+  end
+
+  def test_log
+    get '/log'
+    assert_equal 200, last_response.status
+  end
+end

--- a/views/audit_log.erb
+++ b/views/audit_log.erb
@@ -1,0 +1,18 @@
+<div class="page-header">
+    <h1>Alert Log</h1>
+</div>
+
+<div class="row">
+  <table class="table table-bordered">
+    <tr>
+      <th>Entry</th>
+      <th>Timestamp</th>
+    <tr />
+<% @logs.each do |log| %>
+    <tr>
+      <td><%= log.entry %></td>
+      <td><%= log.timestamp %></td>
+    </tr>
+<% end %>
+  </table>
+</div>

--- a/views/audit_log.erb
+++ b/views/audit_log.erb
@@ -15,4 +15,6 @@
     </tr>
 <% end %>
   </table>
+
+  <%== will_paginate(@logs, params) %>
 </div>

--- a/views/audit_log.erb
+++ b/views/audit_log.erb
@@ -10,8 +10,8 @@
     <tr />
 <% @logs.each do |log| %>
     <tr>
-      <td><%= log.entry %></td>
-      <td><%= log.timestamp %></td>
+      <td><%= log[:entry] %></td>
+      <td><%= DateTime.strptime(log[:timestamp].to_s,'%s') %></td>
     </tr>
 <% end %>
   </table>

--- a/views/audit_log.erb
+++ b/views/audit_log.erb
@@ -1,5 +1,5 @@
 <div class="page-header">
-    <h1>Alert Log</h1>
+    <h1>Audit Log</h1>
 </div>
 
 <div class="row">

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -23,6 +23,7 @@
             <li><a href="/rule/">Rules</a></li>
             <li><a href="/server_directory/">Server Directory</a></li>
             <li><a href="/status">Status</a></li>
+            <li><a href="/log">Audit Log</a></li>
             <li><a href="/api/">API Docs</a></li>
           </ul>
         </div><!-- /.navbar-collapse -->


### PR DESCRIPTION
![2016-09-13 17 27 11](https://cloud.githubusercontent.com/assets/89725/18467063/60786054-79d9-11e6-978b-fc564ebcb34d.png)

There are probably various style bits that will need to be fixed, but this adds a new audit log page to see what actions have been changed recently.

One place that I need feedback on, is the specific content of some of the logging messages, though some of that can be handled in a different pull request