### PR TITLE
Make metrics path configurable

### DIFF
--- a/lib/promgen/config_writer.rb
+++ b/lib/promgen/config_writer.rb
@@ -54,7 +54,7 @@ class Promgen
           project: row[:project],
           farm: row[:farm],
           job: row[:job]
-        }
+        }.merge(row[:path] ? { __metrics_path__: row[:path] } : {})
       end.map do |row|
         {
           targets: row[1].map do |r|

--- a/lib/promgen/repo/project_exporter_repo.rb
+++ b/lib/promgen/repo/project_exporter_repo.rb
@@ -54,7 +54,7 @@ class Promgen
         end
       end
 
-      def register(project_id:, port:, job:)
+      def register(project_id:, port:, job:, path: nil)
         raise ArgumentError, 'port must not be null' if port.nil?
         raise ArgumentError, 'port must not be empty' if port == ''
         raise ArgumentError, 'job must not be null' if job.nil?
@@ -62,18 +62,19 @@ class Promgen
 
         port = port.to_i
 
-        @logger.info "Registering #{project_id}, #{port}, #{job}"
-        if @db[:project_exporter].where(project_id: project_id, port: port).count == 0
+        @logger.info "Registering #{project_id}, #{port}, #{job}, #{path}"
+        if @db[:project_exporter].where(project_id: project_id, port: port, path:path).count == 0
           @db[:project_exporter].insert(project_id: project_id,
                                         port: port,
-                                        job: job)
+                                        job: job,
+                                        path: path)
         end
       end
 
-      def delete(project_id:, port:)
-        @logger.info "removing #{port} from #{project_id}"
+      def delete(project_id:, port:, path:)
+        @logger.info "removing #{port}, #{path} from #{project_id}"
 
-        @db[:project_exporter].where('project_id=? AND port=?', project_id, port).delete
+        @db[:project_exporter].where(project_id: project_id, port: port, path: path).delete
       end
 
       def delete_by_project_id(project_id:)

--- a/lib/promgen/repo/project_repo.rb
+++ b/lib/promgen/repo/project_repo.rb
@@ -78,6 +78,7 @@ class Promgen
         @db['
             SELECT project_exporter.port
               , project_exporter.job
+              , project_exporter.path
               , project.name project
               , project_farm.farm_name farm
               , project_farm.server_directory_id server_directory_id

--- a/lib/promgen/web/route/project_exporter_route.rb
+++ b/lib/promgen/web/route/project_exporter_route.rb
@@ -33,12 +33,13 @@ class Promgen
     post '/project/:project_id/exporter/register' do
       port = params['port']
       job = params['job']
+      path = empty_to_nil(params[:path])
 
-      @project_exporter_service.register(project_id: @project.id, port: port, job: job)
+      @project_exporter_service.register(project_id: @project.id, port: port, job: job, path: path)
 
       @project = @project_service.find(id: @project.id)
       @service = @service_service.find(id: @project.service_id)
-      @audit_log_service.log(entry: "Registered exporter #{job}:#{port} to Service:#{@service.name}/Project:#{@project.name}")
+      @audit_log_service.log(entry: "Registered exporter #{job}:#{port}/#{path} to Service:#{@service.name}/Project:#{@project.name}")
 
       @config_writer.write
 
@@ -47,12 +48,13 @@ class Promgen
 
     post '/project/:project_id/exporter/:port/delete' do
       port = params['port']
+      path = empty_to_nil(params[:path])
 
-      @project_exporter_service.delete(project_id: @project.id, port: port)
+      @project_exporter_service.delete(project_id: @project.id, port: port, path: path)
 
       @project = @project_service.find(id: @project.id)
       @service = @service_service.find(id: @project.service_id)
-      @audit_log_service.log(entry: "Removed exporter #{port} from Service:#{@service.name}/Project:#{@project.name}")
+      @audit_log_service.log(entry: "Removed exporter #{port}/#{path} from Service:#{@service.name}/Project:#{@project.name}")
 
       @config_writer.write
 

--- a/migrations/11_metrics_path.rb
+++ b/migrations/11_metrics_path.rb
@@ -21,20 +21,12 @@
 # THE SOFTWARE.
 
 # frozen_string_literal: true
-class Promgen
-  class ProjectExporter
-    attr_reader :id, :project_id, :port, :job, :path
-
-    def initialize(id:, project_id:, port:, job:, path:)
-      @id = id
-      @project_id = project_id
-      @port = port.to_i
-      @job = job
-      @path = path
-    end
-
-    def values
-      { port: port, job: job, path: path }
+Sequel.migration do
+  change do
+    alter_table(:project_exporter) do
+      add_column :path, String
+      drop_constraint(:unique_project_id_port, :type => :unique)
+      add_unique_constraint([:project_id, :port, :path], :name => :unique_project_id_port_path)
     end
   end
 end

--- a/migrations/5_exporter.rb
+++ b/migrations/5_exporter.rb
@@ -46,7 +46,7 @@ Sequel.migration do
       Integer :port, null: false
       String :job, null: false
 
-      unique [:project_id, :port]
+      unique([:project_id, :port], :name => :unique_project_id_port)
     end
 
     alter_table(:rule) do

--- a/test/promgen/repo/test_project.rb
+++ b/test/promgen/repo/test_project.rb
@@ -59,13 +59,14 @@ class TestProject < Promgen::Test
     project_name = 'project-test'
     service = @app.service_repo.insert(name: 'foo')
     inserted_project_id = @repo.insert(service_id: service.id, name: project_name)
-    @app.project_exporter_repo.register(project_id: inserted_project_id, port: 9100, job: 'node')
+    @app.project_exporter_repo.register(project_id: inserted_project_id, port: 9100, job: 'node', path: '/foo')
 
     @repo.find_exporters.map do |row|
       assert_equal 'foo', row[:service]
       assert_equal 'project-test', row[:project]
       assert_equal 9100, row[:port]
       assert_equal 'node', row[:job]
+      assert_equal '/foo', row[:path]
     end
   end
 end

--- a/test/promgen/test_config_writer.rb
+++ b/test/promgen/test_config_writer.rb
@@ -48,6 +48,7 @@ class TestConfigWriter < Promgen::Test
       server_directory_id: @app.server_directory_repo.find_db.id
     )
     @app.project_exporter_repo.register(project_id: project_id, port: 9010, job: 'node')
+    @app.project_exporter_repo.register(project_id: project_id, port: 9020, job: 'nginx', path: '/foo')
 
     data = @app.config_writer.render_data
     assert_equal [
@@ -59,6 +60,16 @@ class TestConfigWriter < Promgen::Test
           project: 'TestProj'
         },
         targets: ['MYHOST1:9010', 'MYHOST2:9010']
+      },
+      {
+        labels: {
+          __metrics_path__: '/foo',
+          service: 'foo',
+          farm: 'MyFarm',
+          job: 'nginx',
+          project: 'TestProj'
+        },
+        targets: ['MYHOST1:9020', 'MYHOST2:9020']
       }
     ], data
   end

--- a/test/promgen/web/route/test_project_exporter_route.rb
+++ b/test/promgen/web/route/test_project_exporter_route.rb
@@ -51,13 +51,32 @@ class TestProjectExporterRoute < Promgen::Test
     assert_equal 1, exporters.length
     assert_equal 'node', exporters[0].job
     assert_equal 9010, exporters[0].port
+    assert_nil exporters[0].path
+  end
+
+  def test_register_with_path_post
+    project = @factory.project
+
+    post "/project/#{project.id}/exporter/register",
+         port: 9010,
+         job: 'node',
+         path: '/foo'
+
+    assert_equal 302, last_response.status
+
+    exporters = @app.project_exporter_service.all
+    assert_equal 1, exporters.length
+    assert_equal 'node', exporters[0].job
+    assert_equal 9010, exporters[0].port
+    assert_equal '/foo', exporters[0].path
   end
 
   def test_delete
     project = @factory.project
     project_exporter = @factory.project_exporter(project_id: project.id)
 
-    post "/project/#{project.id}/exporter/#{project_exporter.port}/delete"
+    post "/project/#{project.id}/exporter/#{project_exporter.port}/delete",
+         path: project_exporter.path
 
     assert_equal 302, last_response.status
     assert_equal 0, @app.db[:project_exporter].where(id: project_exporter.id).count

--- a/views/list_services.erb
+++ b/views/list_services.erb
@@ -35,6 +35,7 @@
                           <tr>
                             <th><%= exporter.job %></th>
                             <td><%= exporter.port %></td>
+                            <td><%= exporter.path %></td>
                           </tr>
                       <% end %>
                     </table>

--- a/views/register_project_exporter.erb
+++ b/views/register_project_exporter.erb
@@ -20,6 +20,11 @@
         <input type="text" name="job" class="form-control" id="inputJob" required>
         <p class="help-block">nginx, apache, mysqld, node etc.</p>
       </div>
+      <div class="form-group">
+         <label for="inputPath">Metrics Path</label>
+         <input type="text" name="path" class="form-control" id="inputPath">
+         <p class="help-block">/internal/metrics, /my-metrics etc. Optional</p>
+      </div>
       <button type="submit" class="btn btn-default">Register</button>
     </form>
   </div>

--- a/views/register_rule.erb
+++ b/views/register_rule.erb
@@ -18,7 +18,14 @@
     <div class="form-group">
       <label for="inputIf">IF</label>
       <input type="text" name="if" class="form-control" id="inputIf" required>
-      <p class="help-block">Prometheus query. Example: <code>node_load1{...} > 5</code></p>
+      <p class="help-block">Prometheus query to alert on</p>
+      <p class="help-block">
+        Examples
+        <ul>
+          <li><code>node_load1{service="<%= @service.name %>"} > 5</code></li>
+          <li><code>api_http_request_latencies_second{quantile="0.5"} > 1</code></li>
+        </ul>
+      </p>
     </div>
     <div class="form-group">
       <label for="inputFor">FOR</label>
@@ -33,11 +40,23 @@
       <label for="inputLabels">LABELS</label>
       <input type="text" name="labels" class="form-control" id="inputLabels">
       <p class="help-block">A set of additional labels to be attached to the alert. Any existing conflicting labels will be overwritten. The label values can be templated.</p>
+      <p class="help-block">
+        Examples
+        <ul>
+          <li><code>{severity="major"}</code></li>
+        </ul>
+      </p>
     </div>
     <div class="form-group">
       <label for="inputAnnotations">ANNOTATIONS</label>
       <input type="text" name="annotations" class="form-control" id="inputAnnotations">
       <p class="help-block">Another set of labels that are not identifying for an alert instance. They are used to store longer additional information such as alert descriptions or runbook links. The annotation values can be templated.</p>
+      <p class="help-block">
+        Examples
+        <ul>
+          <li><code>{summary="High load on {{ $labels.instance }}", description="..."}</code></li>
+        </ul>
+      </p>
     </div>
 
     <button type="submit" class="btn btn-default">Register</button>

--- a/views/show_project.erb
+++ b/views/show_project.erb
@@ -48,14 +48,17 @@
         <tr>
           <th>Job</th>
           <th>Port</th>
+          <th>Metrics Path</th>
           <th>&nbsp;</th>
         </tr>
         <% @exporters.each do |exporter| %>
             <tr>
               <td><%= exporter.job %></td>
               <td><%= exporter.port %></td>
+              <td><%= exporter.path %></td>
               <td>
                 <form method="post" action="<%= to("/project/#{@project.id}/exporter/#{exporter.port}/delete") %>" onsubmit="return confirm('Delete this exporter?')">
+                  <input type="hidden" name="path" value="<%= exporter.path %>"/>
                   <button type="submit" class="btn btn-danger">Delete</button>
                 </form>
               </td>

--- a/views/show_service.erb
+++ b/views/show_service.erb
@@ -28,6 +28,7 @@
           <tr>
             <th><%= exporter.job %></th>
             <td><%= exporter.port %></td>
+            <td><%= exporter.path %></td>
           </tr>
           <% end %>
         </table>


### PR DESCRIPTION
Apply this change will make metrics path configurable, this will output json file like
```
{
  "targets":[
    "localhost:5000"
  ],
  "labels":{
    "service":"foo",
    "project":"bar",
    "farm":"hoge",
    "job":"hogehoge",
    "__metrics_path__":"/internal/metrics"
  }
}
```

<img width="1239" alt="2016-09-16 17 49 23" src="https://cloud.githubusercontent.com/assets/863983/18580519/13184c10-7c37-11e6-9206-ef1a32027a11.png">
<img width="1248" alt="2016-09-16 17 51 03" src="https://cloud.githubusercontent.com/assets/863983/18580523/1646216e-7c37-11e6-837d-3ac4c8243f96.png">
<img width="1251" alt="2016-09-16 17 54 33" src="https://cloud.githubusercontent.com/assets/863983/18580525/18accd86-7c37-11e6-8dee-b86667083f74.png">

