### PR TITLE
Add rule_writer.render so we can use that in our API

### DIFF
--- a/lib/promgen/rule_writer.rb
+++ b/lib/promgen/rule_writer.rb
@@ -55,23 +55,23 @@ class Promgen
       end
     end
 
+    def render
+      sio = StringIO.new
+      @rule_repo.all.each do |row|
+        sio.puts('ALERT ' + row.values[:alert_clause])
+        sio.puts('IF ' + row.values[:if_clause])
+        sio.puts('FOR ' + row.values[:for_clause]) unless row.values[:for_clause].empty?
+        sio.puts('LABELS ' + row.values[:labels_clause]) unless row.values[:labels_clause].empty?
+        sio.puts('ANNOTATIONS ' + row.values[:annotations_clause]) unless row.values[:annotations_clause].empty?
+      end
+      sio.string
+    end
+
     def write
       @logger.info("Writing #{@rule_path}")
       tmp = @rule_path + '.tmp'
       File.open(tmp, 'w') do |file|
-        @rule_repo.all.each do |row|
-          file.puts('ALERT ' + row.values[:alert_clause])
-          file.puts('IF ' + row.values[:if_clause])
-          unless row.values[:for_clause].empty?
-            file.puts('FOR ' + row.values[:for_clause])
-          end
-          unless row.values[:labels_clause].empty?
-            file.puts('LABELS ' + row.values[:labels_clause])
-          end
-          unless row.values[:annotations_clause].empty?
-            file.puts('ANNOTATIONS ' + row.values[:annotations_clause])
-          end
-        end
+        file.puts(render)
       end
       File.rename(tmp, @rule_path)
 

--- a/lib/promgen/web/route/api_route.rb
+++ b/lib/promgen/web/route/api_route.rb
@@ -74,7 +74,8 @@ class Promgen
     end
 
     get '/api/v1/rule/' do
-      json(rules: @rule_service.all.map(&:values))
+      content_type 'text/plain'
+      @rule_writer.render
     end
 
     get '/api/v1/server_directory/' do


### PR DESCRIPTION
![2016-09-21 11 01 52](https://cloud.githubusercontent.com/assets/89725/18695188/f62b1f26-7fea-11e6-8a2a-d4ec29d0e30f.png)


By refactoring our rule_writer a bit, we can return our rules file from
the API in the same format that we write it to file