### PR TITLE
Modify to resolve rubcop inspection

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,7 +9,7 @@ LineLength:
   Max: 240
 
 MethodLength:
-  Max: 40
+  Max: 50
 
 Documentation:
   Enabled: false

--- a/lib/promgen/repo/project_exporter_repo.rb
+++ b/lib/promgen/repo/project_exporter_repo.rb
@@ -63,7 +63,7 @@ class Promgen
         port = port.to_i
 
         @logger.info "Registering #{project_id}, #{port}, #{job}, #{path}"
-        if @db[:project_exporter].where(project_id: project_id, port: port, path:path).count == 0
+        if @db[:project_exporter].where(project_id: project_id, port: port, path: path).count == 0
           @db[:project_exporter].insert(project_id: project_id,
                                         port: port,
                                         job: job,

--- a/migrations/11_metrics_path.rb
+++ b/migrations/11_metrics_path.rb
@@ -25,8 +25,8 @@ Sequel.migration do
   change do
     alter_table(:project_exporter) do
       add_column :path, String
-      drop_constraint(:unique_project_id_port, :type => :unique)
-      add_unique_constraint([:project_id, :port, :path], :name => :unique_project_id_port_path)
+      drop_constraint(:unique_project_id_port, type: :unique)
+      add_unique_constraint([:project_id, :port, :path], name: :unique_project_id_port_path)
     end
   end
 end

--- a/migrations/5_exporter.rb
+++ b/migrations/5_exporter.rb
@@ -46,7 +46,7 @@ Sequel.migration do
       Integer :port, null: false
       String :job, null: false
 
-      unique([:project_id, :port], :name => :unique_project_id_port)
+      unique([:project_id, :port], name: :unique_project_id_port)
     end
 
     alter_table(:rule) do


### PR DESCRIPTION
Although rubocop points out test/promgen/test_config_writer.rb, I think that test/promgen/test_config_writer.rb is valid. So I change .rubocop.yml.

```
$ rubocop
Inspecting 93 files
.....................C................................C....C...................C.............

Offenses:

lib/promgen/repo/project_exporter_repo.rb:66:81: C: Space missing after colon.
        if @db[:project_exporter].where(project_id: project_id, port: port, path:path).count == 0
                                                                                ^
migrations/11_metrics_path.rb:28:48: C: Use the new Ruby 1.9 hash syntax.
      drop_constraint(:unique_project_id_port, :type => :unique)
                                               ^^^^^^^^
migrations/11_metrics_path.rb:29:58: C: Use the new Ruby 1.9 hash syntax.
      add_unique_constraint([:project_id, :port, :path], :name => :unique_project_id_port_path)
                                                         ^^^^^^^^
migrations/5_exporter.rb:49:36: C: Use the new Ruby 1.9 hash syntax.
      unique([:project_id, :port], :name => :unique_project_id_port)
                                   ^^^^^^^^
test/promgen/test_config_writer.rb:30:3: C: Method has too many lines. [41/40]
  def test_render_data ...
  ^^^^^^^^^^^^^^^^^^^^

93 files inspected, 5 offenses detected
```