### PR TITLE
Trigger write api

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,26 @@ When you specify the Webhook module, you need to specify the URL for each projec
 
 Specify the Alerta module and the URL set in your environment.
 
+### 6. Notification Hooks
+
+When Promgen writes it's target configuration file or alerting rules file, it can optionally post a notification to an external service.
+This is primarily useful for keeping configuration files in sync while running multiple Prometheus+Promgen servers in parallel
+
+```yaml
+config_writer:
+  path: /tmp/prom.json
+  notify:
+    - http://promgen.other/api/v1/config
+rule_writer:
+  rule_path: /tmp/prom.rule
+  promtool_path: /path/to/promtool
+  notify:
+    - http://promgen.other/api/v1/rule/
+```
+
+In this example, our Promgen instance will POST a notification to another Promgen instance to trigger it to output it's configuration
+file to keep things in sync.
+
 ## The MIT License
 
 Copyright (c) 2016 LINE Corporation

--- a/config.ru
+++ b/config.ru
@@ -18,5 +18,6 @@ run Rack::URLMap.new(
   '/alert/' => Rack::Auth::Basic.new(app.alert) do |username, password|
     username == 'promgen' && password == app.config['password']
   end,
+  '/api' => app.api,
   '/' => Rack::Protection::RemoteReferrer.new(app.web, allow_empty_referrer: false)
 )

--- a/config.sample.yml
+++ b/config.sample.yml
@@ -6,9 +6,13 @@ db:
   logging: false
 config_writer:
   path: /tmp/prom.json
+  notify:
+    - http://promgen.other/api/v1/config
 rule_writer:
   rule_path: /tmp/prom.rule
   promtool_path: /path/to/promtool
+  notify:
+    - http://promgen.other/api/v1/rule/
 alert_senders:
   - module: Ikachan
     url: http://ikachan.localhost/

--- a/lib/promgen.rb
+++ b/lib/promgen.rb
@@ -54,6 +54,7 @@ require 'promgen/service/server_directory_service'
 require 'promgen/service/service_service'
 
 require 'promgen/web'
+require 'promgen/api'
 require 'promgen/prometheus'
 require 'promgen/server_directory/db'
 
@@ -94,6 +95,7 @@ class Promgen
   register :audit_log_service, Promgen::Service::AuditService
 
   register :web,                  Promgen::Web
+  register :api,                  Promgen::API
   register :config_writer,        Promgen::ConfigWriter
   register :rule_writer,          Promgen::RuleWriter
   register :alert,                Promgen::Alert

--- a/lib/promgen/api.rb
+++ b/lib/promgen/api.rb
@@ -27,20 +27,32 @@ require 'sinatra/json'
 require 'erubis'
 
 class Promgen
-  class Web < Sinatra::Base
-    get '/api/' do
+  class API < Sinatra::Base
+    def initialize(
+        rule_service:,
+        config_writer:,
+        rule_writer:,
+        logger:
+    )
+      super()
+      @config_writer = config_writer
+      @rule_writer = rule_writer
+      @logger = logger
+    end
+
+    get '/' do
       erb :api
     end
 
-    get '/api/v1/config' do
+    get '/v1/config' do
       @config_writer.render
     end
 
-    get '/api/v1/project/' do
+    get '/v1/project/' do
       json(projects: @project_service.all.map(&:values))
     end
 
-    get '/api/v1/project/:project_id' do
+    get '/v1/project/:project_id' do
       project = @project_service.find(id: params[:project_id])
       halt 404 unless project
       val = { project: project.values }
@@ -58,11 +70,11 @@ class Promgen
       json(val)
     end
 
-    get '/api/v1/farm/' do
+    get '/v1/farm/' do
       json(farms: @farm_service.all.map(&:values))
     end
 
-    get '/api/v1/farm/:farm_id' do
+    get '/v1/farm/:farm_id' do
       farm_id = params['farm_id'].to_i
       farm = @farm_service.find(id: farm_id)
       halt 404 unless farm
@@ -73,16 +85,16 @@ class Promgen
       json(val)
     end
 
-    get '/api/v1/rule/' do
+    get '/v1/rule/' do
       content_type 'text/plain'
       @rule_writer.render
     end
 
-    get '/api/v1/server_directory/' do
+    get '/v1/server_directory/' do
       json(server_directories: @server_directory_service.all.map(&:values))
     end
 
-    get '/api/v1/server_directory/type/' do
+    get '/v1/server_directory/type/' do
       types = @server_directory_service.types
                                        .map(&:values)
       json(types: types)

--- a/lib/promgen/api.rb
+++ b/lib/promgen/api.rb
@@ -29,16 +29,35 @@ require 'erubis'
 class Promgen
   class API < Sinatra::Base
     def initialize(
-        rule_service:,
         config_writer:,
         rule_writer:,
+
+        farm_service:,
+        host_service:,
+        project_exporter_service:,
+        project_farm_service:,
+        project_service:,
+        rule_service:,
+        server_directory_service:,
+
         logger:
     )
       super()
       @config_writer = config_writer
       @rule_writer = rule_writer
+
+      @farm_service = farm_service
+      @host_service = host_service
+      @project_exporter_service = project_exporter_service
+      @project_farm_service = project_farm_service
+      @project_service = project_service
+      @server_directory_service = server_directory_service
+
       @logger = logger
     end
+
+    set :erb, escape_html: true
+    set :root, File.join(File.dirname(__FILE__), '..', '..')
 
     get '/' do
       erb :api

--- a/lib/promgen/api.rb
+++ b/lib/promgen/api.rb
@@ -48,6 +48,11 @@ class Promgen
       @config_writer.render
     end
 
+    post '/v1/config' do
+      @config_writer.write
+      'ok'
+    end
+
     get '/v1/project/' do
       json(projects: @project_service.all.map(&:values))
     end
@@ -88,6 +93,11 @@ class Promgen
     get '/v1/rule/' do
       content_type 'text/plain'
       @rule_writer.render
+    end
+
+    post '/v1/rule/' do
+      @rule_writer.write
+      'ok'
     end
 
     get '/v1/server_directory/' do

--- a/lib/promgen/api.rb
+++ b/lib/promgen/api.rb
@@ -37,7 +37,6 @@ class Promgen
         project_exporter_service:,
         project_farm_service:,
         project_service:,
-        rule_service:,
         server_directory_service:,
 
         logger:

--- a/lib/promgen/api.rb
+++ b/lib/promgen/api.rb
@@ -49,7 +49,7 @@ class Promgen
     end
 
     post '/v1/config' do
-      @config_writer.write
+      @config_writer.write(notify: false)
       'ok'
     end
 
@@ -96,7 +96,7 @@ class Promgen
     end
 
     post '/v1/rule/' do
-      @rule_writer.write
+      @rule_writer.write(notify: false)
       'ok'
     end
 

--- a/lib/promgen/config_writer.rb
+++ b/lib/promgen/config_writer.rb
@@ -34,7 +34,7 @@ class Promgen
       @prometheus = prometheus
       @project_repo = project_repo
       @server_directory_repo = server_directory_repo
-      @notify = config[:config_writer][:notify]
+      @notify = config[:config_writer][:notify] ||= []
     end
 
     def render

--- a/lib/promgen/config_writer.rb
+++ b/lib/promgen/config_writer.rb
@@ -26,7 +26,7 @@ require 'json'
 class Promgen
   class ConfigWriter
     # @param [Promgen::ServerLoader::Base] server_directory_repo
-    def initialize(logger:, path:, host_repo:, prometheus:, project_repo:, server_directory_repo:)
+    def initialize(logger:, path:, host_repo:, prometheus:, project_repo:, server_directory_repo:, config:)
       raise ArgumentError, 'Destination path must not be null' unless path
       @logger = logger
       @destpath = path
@@ -34,6 +34,7 @@ class Promgen
       @prometheus = prometheus
       @project_repo = project_repo
       @server_directory_repo = server_directory_repo
+      @notify = config[:config_writer][:notify]
     end
 
     def render
@@ -67,11 +68,19 @@ class Promgen
       end
     end
 
-    def write
+    def write(notify: true)
       @logger.info("Writing #{@destpath}")
       tmp = @destpath + '.tmp'
       File.write(tmp, render)
       File.rename(tmp, @destpath)
+
+      if notify
+        @notify.each do |url|
+          uri = URI(url)
+          res = Net::HTTP.post_form(uri, {})
+          @logger.info("Posted notification to: #{uri}: #{res.body}")
+        end
+      end
 
       @prometheus.reload
     end

--- a/lib/promgen/rule_writer.rb
+++ b/lib/promgen/rule_writer.rb
@@ -34,7 +34,7 @@ class Promgen
       @promtool_path = promtool_path
       @rule_repo = rule_repo
       @prometheus = prometheus
-      @notify = config[:rule_writer][:notify]
+      @notify = config[:rule_writer][:notify] ||= []
     end
 
     def nil_or_empty?(s)

--- a/lib/promgen/web.rb
+++ b/lib/promgen/web.rb
@@ -24,7 +24,6 @@
 require 'sinatra/base'
 require 'sinatra/json'
 
-require 'promgen/web/route/api_route'
 require 'promgen/web/route/farm_route'
 require 'promgen/web/route/project_route'
 require 'promgen/web/route/status_route'

--- a/public/css/promgen.css
+++ b/public/css/promgen.css
@@ -1,0 +1,7 @@
+.label-get {
+  background-color: blue
+}
+
+.label-post {
+  background-color: green
+}

--- a/test/promgen/test.rb
+++ b/test/promgen/test.rb
@@ -65,11 +65,13 @@ class Promgen
           'level' => ENV['LOG_LEVEL'] || 'warn'
         },
         'config_writer' => {
-          'path' => '/tmp/xxx.json'
+          'path' => '/tmp/xxx.json',
+          'notify' => ['http://promgen.localhost/api/v1/config']
         },
         'rule_writer' => {
           'rule_path' => '/tmp/xxx.rule',
-          'promtool_path' => '/tmp/promtool'
+          'promtool_path' => '/tmp/promtool',
+          'notify' => ['http://promgen.localhost/api/v1/rules/']
         },
         'prometheus' => {
           'url' => 'http://prom.localhost'
@@ -92,6 +94,8 @@ class Promgen
       @app.migrator.run
 
       stub_request(:post, 'http://prom.localhost/-/reload').to_return(status: 200)
+      stub_request(:post, 'http://promgen.localhost/api/v1/config').to_return(status: 200)
+      stub_request(:post, 'http://promgen.localhost/api/v1/rules/').to_return(status: 200)
 
       @factory = @app.get_bean(Promgen::Factory)
     end

--- a/test/promgen/test_api.rb
+++ b/test/promgen/test_api.rb
@@ -23,7 +23,9 @@
 # frozen_string_literal: true
 require 'promgen/test'
 
-class TestStatus < Promgen::Test
+require 'promgen'
+
+class TestAPI < Promgen::Test
   include Rack::Test::Methods
 
   def app

--- a/test/promgen/web/test_api.rb
+++ b/test/promgen/web/test_api.rb
@@ -27,48 +27,48 @@ class TestStatus < Promgen::Test
   include Rack::Test::Methods
 
   def app
-    @app.web
+    @app.api
   end
 
   def test_api
-    get '/api/'
+    get '/'
     assert_equal 200, last_response.status
   end
 
   def test_api_config
-    get '/api/v1/config'
+    get '/v1/config'
     assert_equal 200, last_response.status
   end
 
   def test_api_project
-    get '/api/v1/project/'
+    get '/v1/project/'
     assert_equal 200, last_response.status
   end
 
   def test_api_project_show
     project_id = @factory.project.id
-    get "/api/v1/project/#{project_id}"
+    get "/v1/project/#{project_id}"
     assert_equal 200, last_response.status
   end
 
   def test_api_farm
-    get '/api/v1/farm/'
+    get '/v1/farm/'
     assert_equal 200, last_response.status
   end
 
   def test_api_farm_show
     farm = @factory.farm(name: 'iii-ALPHA')
-    get "/api/v1/farm/#{farm.id}"
+    get "/v1/farm/#{farm.id}"
     assert_equal 200, last_response.status
   end
 
   def test_api_server_directory_list
-    get '/api/v1/server_directory/'
+    get '/v1/server_directory/'
     assert_equal 200, last_response.status
   end
 
   def test_api_server_directory_types
-    get '/api/v1/server_directory/type/'
+    get '/v1/server_directory/type/'
     assert_equal 200, last_response.status
   end
 end

--- a/views/api.erb
+++ b/views/api.erb
@@ -16,19 +16,31 @@
       <th>Description</th>
     </tr>
     <tr>
-      <td>/api/v1/config</td>
-      <td>config.json</td>
+      <td><span class="label label-get">GET</span> /api/v1/config</td>
+      <td>Retrieve Prometheus target configuration</td>
     </tr>
     <tr>
-      <td>/api/v1/project/</td>
+      <td><span class="label label-post">POST</span> /api/v1/config</td>
+      <td>Trigger Promgen to write Prometheus target configuration to disk</td>
+    </tr>
+    <tr>
+      <td><span class="label label-get">GET</span> /api/v1/rule/</td>
+      <td>Retrieve Prometheus alerting Rules</td>
+    </tr>
+    <tr>
+      <td><span class="label label-post">POST</span> /api/v1/rule/</td>
+      <td>Trigger Promgen to write Prometheus alerting rules to disk</td>
+    </tr>
+    <tr>
+      <td><span class="label label-get">GET</span> /api/v1/project/</td>
       <td>List of projects</td>
     </tr>
     <tr>
-      <td>/api/v1/farm/</td>
+      <td><span class="label label-get">GET</span> /api/v1/farm/</td>
       <td>List of farms</td>
     </tr>
     <tr>
-      <td>/api/v1/farm/:farm_id</td>
+      <td><span class="label label-get">GET</span> /api/v1/farm/:farm_id</td>
       <td>Get farm information</td>
     </tr>
   </table>

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -8,6 +8,7 @@
     <meta name="viewport" content="width=device-width, minimum-scale=1.0, maximum-scale=1.0" />
     <meta name="format-detection" content="telephone=no" />
     <link rel="stylesheet" href="/css/bootstrap.min.css">
+    <link rel="stylesheet" href="/css/promgen.css">
   </head>
   <body>
 


### PR DESCRIPTION
Since Promgen manages the configuration file for Prometheus, it’s normal for Promgen and Prometheus to be paired together on the same server. Once you have multiple servers for load balancing and failover, it becomes more difficult to keep the configuration files in sync.

This pull request adds two enhancements.

1) POSTing to /api/v1/config and /api/v1/rule/ will trigger to Promgen to write it’s configuration changes to disk.

2) Add notification hooks to config_writer and rule_writer to POST updates to configured endpoints on updates.

```yaml
# Config for promgen1.local
config_writer:
  path: /tmp/prom.json
  notify:
    - http://promgen.other/api/v1/config
rule_writer:
  rule_path: /tmp/prom.rule
  promtool_path: /path/to/promtool
  notify:
    - http://promgen.other/api/v1/rule/
```

Assuming that each Promgen instance shares the same database, this allows one to have multiple, load balanced promgen instances where trigging a write on one instance, will also trigger writes on the other instances.


I also moved the API routes to be it’s own controller (instead of a child of app.web) to allow different Rack settings to be applied separate from /alerts and other web endpoints.

Since the Promgen POST endpoints ignore the POST body, it would be easy to add a Pushgateway compatible body, and have Promgen send a last_updated_timestamp to Pushgateway to be used in other metrics or notifications