### PR TITLE
Fix the breadcrumbs to show the full hierarchy

### DIFF
--- a/lib/promgen/web/route/host_route.rb
+++ b/lib/promgen/web/route/host_route.rb
@@ -28,6 +28,7 @@ class Promgen
   class Web < Sinatra::Base
     # Add new host to the farm
     get '/project/:project_id/farm/:farm_id/host/add' do
+      @service = @service_service.find(id: @project.service_id)
       @farm = @farm_service.find(id: params[:farm_id])
       erb :add_host
     end

--- a/lib/promgen/web/route/project_exporter_route.rb
+++ b/lib/promgen/web/route/project_exporter_route.rb
@@ -27,6 +27,7 @@ require 'sinatra/json'
 class Promgen
   class Web < Sinatra::Base
     get '/project/:project_id/exporter/register' do
+      @service = @service_service.find(id: @project.service_id)
       erb :register_project_exporter
     end
 

--- a/lib/promgen/web/route/project_route.rb
+++ b/lib/promgen/web/route/project_route.rb
@@ -80,6 +80,7 @@ class Promgen
     end
 
     get '/project/:project_id/update' do
+      @service = @service_service.find(id: @project.service_id)
       erb :update_project
     end
 

--- a/views/add_host.erb
+++ b/views/add_host.erb
@@ -1,5 +1,6 @@
 <ol class="breadcrumb">
     <li><a href="/">Home</a></li>
+    <li><a href="<%= to("/service/#{@service.id}") %>"><%= @service.name %></a></li>
     <li><a href="<%= to("/project/#{@project.id}") %>"><%= @project.name %></a></li>
     <li class="active">Register new Host</li>
 </ol>
@@ -21,4 +22,3 @@
   </form>
 </div>
 </div>
-

--- a/views/register_project_exporter.erb
+++ b/views/register_project_exporter.erb
@@ -1,5 +1,6 @@
 <ol class="breadcrumb">
   <li><a href="/">Home</a></li>
+  <li><a href="<%= to("/service/#{@service.id}") %>"><%= @service.name %></a></li>
   <li><a href="<%= to("/project/#{@project.id}") %>"><%= @project.name %></a></li>
   <li class="active">Register new project exporter</li>
 </ol>

--- a/views/show_rule.erb
+++ b/views/show_rule.erb
@@ -1,6 +1,6 @@
 <ol class="breadcrumb">
   <li><a href="/">Home</a></li>
-  <li class="active"><%= @service.name %></li>
+  <li class="active"><a href="<%= to("/service/#{@service.id}") %>"><%= @service.name %></a></li>
 </ol>
 
 <div class="page-header">

--- a/views/update_project.erb
+++ b/views/update_project.erb
@@ -1,5 +1,6 @@
 <ol class="breadcrumb">
   <li><a href="/">Home</a></li>
+  <li><a href="<%= to("/service/#{@service.id}") %>"><%= @service.name %></a></li>
   <li><a href="<%= to("/project/#{@project.id}") %>"><%= @project.name %></a></li>
   <li class="active">Update project</li>
 </ol>


### PR DESCRIPTION
![2016-10-03 10 58 40](https://cloud.githubusercontent.com/assets/89725/19025769/5f681824-8958-11e6-9365-997dfb60705b.png)

Service was missing on a few pages, so this should fix it to show the proper hierarchy


Home
Home > Service
Home > Service > Project
Home > Service > Project > etc