### PR TITLE
Fix robucop inspection result

### DIFF
--- a/lib/promgen/web/route/rule_route.rb
+++ b/lib/promgen/web/route/rule_route.rb
@@ -33,7 +33,7 @@ class Promgen
 
     get '/service/:service_id/rule/register' do
       @service = @service_service.find(id: params[:service_id])
-      @rule = Promgen::Rule.new()
+      @rule = Promgen::Rule.new
       erb :register_rule
     end
 

--- a/migrations/13_rule_text_length.rb
+++ b/migrations/13_rule_text_length.rb
@@ -23,9 +23,9 @@
 Sequel.migration do
   change do
     alter_table :rule do
-      set_column_type :if_clause, String, :text=>true
-      set_column_type :labels_clause, String, :text=>true
-      set_column_type :annotations_clause, String, :text=>true
+      set_column_type :if_clause, String, text: true
+      set_column_type :labels_clause, String, text: true
+      set_column_type :annotations_clause, String, text: true
     end
   end
 end


### PR DESCRIPTION
```
$ rubocop
Inspecting 96 files
................................................C........C......................................

Offenses:

lib/promgen/web/route/rule_route.rb:36:32: C: Do not use parentheses for method calls with no arguments.
      @rule = Promgen::Rule.new()
                               ^
migrations/13_rule_text_length.rb:26:43: C: Use the new Ruby 1.9 hash syntax.
      set_column_type :if_clause, String, :text=>true
                                          ^^^^^^^
migrations/13_rule_text_length.rb:26:48: C: Surrounding space missing for operator =>.
      set_column_type :if_clause, String, :text=>true
                                               ^^
migrations/13_rule_text_length.rb:27:47: C: Use the new Ruby 1.9 hash syntax.
      set_column_type :labels_clause, String, :text=>true
                                              ^^^^^^^
migrations/13_rule_text_length.rb:27:52: C: Surrounding space missing for operator =>.
      set_column_type :labels_clause, String, :text=>true
                                                   ^^
migrations/13_rule_text_length.rb:28:52: C: Use the new Ruby 1.9 hash syntax.
      set_column_type :annotations_clause, String, :text=>true
                                                   ^^^^^^^
migrations/13_rule_text_length.rb:28:57: C: Surrounding space missing for operator =>.
      set_column_type :annotations_clause, String, :text=>true
                                                        ^^

96 files inspected, 7 offenses detected
```