### PR TITLE
fixed "Getting started" manual.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,17 +21,23 @@ Below are the steps to get started with Promgen.
 Initialize Promgen using Docker.
 
 ```bash
+# Create promgen setting directory.
+mkdir -p ~/.config/promgen
+chmod 777 ~/.config/promgen
+
 # Initialize required settings with Docker container
 # This will prompt you for connection settings for your database and Redis broker
 # using the standard DSN syntax.
 # Database example: mysql://password:username@hostname/databasename
 # Broker example: redis://localhost:6379/0
-docker run --rm --network host -v ~/.config/promgen:/etc/promgen/ promgen:latest bootstrap
+docker run --rm -it -v ~/.config/promgen:/etc/promgen/ line/promgen:master bootstrap
+
 # Apply database updates
-docker run --rm --network host -v ~/.config/promgen:/etc/promgen/ promgen:latest migrate
+docker run --rm -v ~/.config/promgen:/etc/promgen/ line/promgen:master migrate
+
 # Create initial login user. This is the same as the default django-admin command
 # https://docs.djangoproject.com/en/1.10/ref/django-admin/#django-admin-createsuperuser
-docker run --rm -it --network host -v ~/.config/promgen:/etc/promgen/ promgen:latest createsuperuser
+docker run --rm -it -v ~/.config/promgen:/etc/promgen/ line/promgen:master createsuperuser
 ```
 
 You can then use your favorite configuration management system to deploy to each worker.
@@ -54,10 +60,10 @@ Run Promgen using the following command.
 
 ```bash
 # Run Promgen web worker. This is typically balanced behind an NGINX instance
-docker run --rm --network host -p 8000:8000 -v ~/.config/promgen:/etc/promgen/ promgen:latest web
+docker run --rm -p 8000:8000 -v ~/.config/promgen:/etc/promgen/ line/promgen:master
 
 # Run Promgen celery worker. Make sure to run it on the same machine as your Prometheus server to manage the config settings
-docker run --rm --network host -v ~/.config/promgen:/etc/promgen/ -v /etc/prometheus:/etc/prometheus promgen:latest worker
+docker run --rm -v ~/.config/promgen:/etc/promgen/ -v /etc/prometheus:/etc/prometheus line/promgen:master worker
 ```
 
 ## How to contribute to Promgen


### PR DESCRIPTION
I was going to install promgen according to "Getting started" in README.md.
However, many errors occurred.

As a result of trial and error, I successfully installed it, so Pull Request does it.

The modifications are listed below.

- fix specified docker repository:tag. `promgen:latest` -> `line/promgen:master`
  `promgen:latest` [does not exist](https://hub.docker.com/r/line/promgen/tags/).  I suggest to make `latest` tag (According to convention of docker.)
- remove `--network host`. 
  Generally, port may overlap with host machine, I think that `--network host` should be avoided.
- add `chmod 777 ~/.config/promgen`.  
  If do not do this, Permission denied has occurred.
 ```
# docker run --rm -v ~/.config/promgen:/etc/promgen/ line/promgen:master bootstrap
/usr/src/app/promgen/settings.py:37: UserWarning: Unset SECRET_KEY setting to random for now
  warnings.warn('Unset SECRET_KEY setting to random for now')
Bootstrapping Promgen
Creating promgen config /etc/promgen/promgen.yml from /usr/src/app/promgen/tests/examples/promgen.yml
Traceback (most recent call last):
  File "/usr/local/bin/promgen", line 11, in <module>
    load_entry_point('Promgen', 'console_scripts', 'promgen')()
  File "/usr/src/app/promgen/manage.py", line 20, in main
    execute_from_command_line(sys.argv)
  File "/usr/local/lib/python3.5/site-packages/django/core/management/__init__.py", line 364, in execute_from_command_line
    utility.execute()
  File "/usr/local/lib/python3.5/site-packages/django/core/management/__init__.py", line 356, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/usr/local/lib/python3.5/site-packages/django/core/management/base.py", line 283, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/usr/local/lib/python3.5/site-packages/django/core/management/base.py", line 330, in execute
    output = self.handle(*args, **options)
  File "/usr/src/app/promgen/management/commands/bootstrap.py", line 54, in handle
    shutil.copy(path, settings.PROMGEN_CONFIG)
  File "/usr/local/lib/python3.5/shutil.py", line 241, in copy
    copyfile(src, dst, follow_symlinks=follow_symlinks)
  File "/usr/local/lib/python3.5/shutil.py", line 121, in copyfile
    with open(dst, 'wb') as fdst:
PermissionError: [Errno 13] Permission denied: '/etc/promgen/promgen.yml'
```
- add `-it` option in bootstrap flow.
  Because display prompt, `-i (STDIN open)` option is necessary.
- remove `web` argument in run web flow.
  Because CMD and ENTRYPOINT are specified in Dockerfile, If pass arguments when docker run, CMD will be override.
  That is, if you specify only `web`, `"--bind", "0.0.0.0:8000", "--workers", "4"` are ignored. I could not access the web UI because "0.0.0.0: 8000" is not bind.

FYI, Docker version is listed below.
```
# docker -v
Docker version 17.09.0-ce, build afdb6d4
```