### PR TITLE
Added slack notifier

### DIFF
--- a/promgen/notification/slack.py
+++ b/promgen/notification/slack.py
@@ -1,0 +1,50 @@
+# These sources are released under the terms of the MIT license: see LICENSE
+
+import logging
+
+from django import forms
+
+from promgen import util
+from promgen.notification import NotificationBase
+
+logger = logging.getLogger(__name__)
+
+
+class FormSlack(forms.Form):
+    value = forms.CharField(
+        required=True,
+        label='Slack webhook URL'
+    )
+    alias = forms.CharField(
+        required=False,
+        help_text='Optional description to be displayed instead of the URL.'
+    )
+
+class NotificationSlack(NotificationBase):
+    '''
+    Send messages to slack via webhook.
+
+    A webhook has to be configured for your workspace; you
+    can set one up here:
+
+    https://my.slack.com/services/new/incoming-webhook/
+
+    A fitting prometheus icon can be selected from here:
+
+    https://github.com/quintessence/slack-icons
+    '''
+
+    form = FormSlack
+
+    def _send(self, url, data):
+        if data['status'] == 'resolved':
+            message = self.render('promgen/sender/slack.resolved.txt', data)
+        else:
+            message = self.render('promgen/sender/slack.body.txt', data)
+
+        json = {
+            'text': message,
+        }
+
+        util.post(url, json=json).raise_for_status()
+

--- a/promgen/templates/promgen/sender/slack.body.txt
+++ b/promgen/templates/promgen/sender/slack.body.txt
@@ -1,0 +1,8 @@
+{% autoescape off %}[{{ status }}]{% for k,v in commonLabels.items|dictsort:0 %} {{ v }}{% endfor %}
+{% for k,v in commonAnnotations.items|dictsort:0 %}
+{{ k|title }}: {{ v }}{% endfor %}
+{% for alert in alerts %}
+Labels: {% for k,v in alert.labels.items|dictsort:0 %}{% if k not in commonLabels %}{{ v }} {% endif %}{% endfor %}{% for k,v in alert.annotations.items|dictsort:0 %}{% if k not in commonAnnotations %}
+{{ k|title }}: {{ v }}{% endif %}{% endfor %}
+Source: {{ alert.generatorURL }}
+{% endfor %}{% endautoescape %}

--- a/promgen/templates/promgen/sender/slack.resolved.txt
+++ b/promgen/templates/promgen/sender/slack.resolved.txt
@@ -1,0 +1,1 @@
+{% autoescape off %}[{{ status }}]{% for k,v in commonLabels.items|dictsort:0 %} {{ v }}{% endfor %}{% endautoescape %}

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,7 @@ setup(
             'email = promgen.notification.email:NotificationEmail',
             'ikasan = promgen.notification.ikasan:NotificationIkasan',
             'linenotify = promgen.notification.linenotify:NotificationLineNotify',
+            'slack = promgen.notification.slack:NotificationSlack',
             'user = promgen.notification.user:NotificationUser',
             'webhook = promgen.notification.webhook:NotificationWebhook',
         ],


### PR DESCRIPTION
Added slack notifier.

The notifier requires a [Slack Webhook](https://api.slack.com/incoming-webhooks) to be configured in advance.

