### PR TITLE
Fix bytes/str mismatch with writing rules

### DIFF
--- a/promgen/management/commands/rules.py
+++ b/promgen/management/commands/rules.py
@@ -32,4 +32,7 @@ class Command(BaseCommand):
                 version=kwargs['version']
             )
         else:
+            # Since we're already working with utf8 encoded data, we can skip
+            # the newline ending here
+            self.stdout.ending = None
             self.stdout.write(prometheus.render_rules(version=kwargs['version']))

--- a/promgen/tests/examples/promgen.yml
+++ b/promgen/tests/examples/promgen.yml
@@ -6,7 +6,7 @@ prometheus:
   # Path to promtool to verify valid rules file
   promtool: /usr/local/bin/promtool
   # Output rule configuration to this path
-  rules: /etc/prometheus/promgen.rule
+  rules: /etc/prometheus/promgen.rule.yml
 
 alertmanager:
   url: http://alertmanager:9093

--- a/promgen/tests/test_rules.py
+++ b/promgen/tests/test_rules.py
@@ -19,7 +19,7 @@ ALERT RuleName
   ANNOTATIONS {rule="http://example.com/rule/%d/edit", summary="Test case"}
 
 
-'''.lstrip()
+'''.lstrip().encode('utf-8')
 
 _RULE_NEW = '''
 groups:


### PR DESCRIPTION
Updated test cases and ensure that render_rules always works with bytes
to handle this mismatch between using yaml.safe_dump with utf8 and
json.dump

This expands on the bit that @seoester filed in #39 along with ensuring our test cases and django management command still work and handle things properly