### PR TITLE
Enable debug mode when environment variable DEBUG is set

### DIFF
--- a/promgen/settings.py
+++ b/promgen/settings.py
@@ -40,7 +40,7 @@ if not SECRET_KEY:
     SECRET_KEY = get_random_string(50, 'abcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*(-_=+)')
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = os.path.exists(os.path.join(CONFIG_DIR, 'DEBUG'))
+DEBUG = 'DEBUG' in os.environ and os.environ['DEBUG'] != '0'
 
 # Settings for Prometheus paths and such
 PROMGEN_CONFIG = os.path.join(CONFIG_DIR, 'promgen.yml')

--- a/promgen/settings.py
+++ b/promgen/settings.py
@@ -40,7 +40,7 @@ if not SECRET_KEY:
     SECRET_KEY = get_random_string(50, 'abcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*(-_=+)')
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = 'DEBUG' in os.environ and os.environ['DEBUG'] != '0'
+DEBUG = os.environ.get('DEBUG', '0') != '0'
 
 # Settings for Prometheus paths and such
 PROMGEN_CONFIG = os.path.join(CONFIG_DIR, 'promgen.yml')


### PR DESCRIPTION
The change allows setting the environment variable DEBUG to any value except '0' to enable the django debug mode.
Placing a non-empty file `DEBUG` in the `CONFIG_DIR` has the same effect (the file is loaded by the `envdir` module).

Note: Previously it was possible to enable the debug mode by leaving the `DEBUG` file empty. This would **not** be possible anymore after merging this PR.

Personally, I think it is worth breaking this functionality for higher compatibility with `envdir` and to keep the code more maintainable.
However, if you'd prefer to keep this feature, please get back to me.

