### PR TITLE
Fix display message when registering a duplicate Service

### DIFF
--- a/promgen/forms.py
+++ b/promgen/forms.py
@@ -90,19 +90,26 @@ class ExporterForm(forms.ModelForm):
         }
 
 
-class ServiceForm(forms.ModelForm):
+class ServiceRegister(forms.ModelForm):
+    class Meta:
+        model = models.Service
+        # shard is determined by the pk in the service register url
+        exclude = ['shard']
+
+
+class ServiceUpdate(forms.ModelForm):
     class Meta:
         model = models.Service
         exclude = []
 
 
-class ProjectForm(forms.ModelForm):
+class ProjectRegister(forms.ModelForm):
     class Meta:
         model = models.Project
         exclude = ['service', 'farm']
 
 
-class ProjectMove(forms.ModelForm):
+class ProjectUpdate(forms.ModelForm):
     class Meta:
         model = models.Project
         exclude = ['farm']

--- a/promgen/views.py
+++ b/promgen/views.py
@@ -569,7 +569,7 @@ class ProjectRegister(LoginRequiredMixin, FormView, ServiceMixin):
     button_label = _('Project Register')
     model = models.Project
     template_name = 'promgen/project_form.html'
-    form_class = forms.ProjectForm
+    form_class = forms.ProjectRegister
 
     def form_valid(self, form):
         service = get_object_or_404(models.Service, id=self.kwargs['pk'])
@@ -581,7 +581,7 @@ class ProjectUpdate(LoginRequiredMixin, UpdateView):
     model = models.Project
     button_label = _('Project Update')
     template_name = 'promgen/project_form.html'
-    form_class = forms.ProjectMove
+    form_class = forms.ProjectUpdate
 
     def get_context_data(self, **kwargs):
         context = super(ProjectUpdate, self).get_context_data(**kwargs)
@@ -591,7 +591,7 @@ class ProjectUpdate(LoginRequiredMixin, UpdateView):
 
 class ServiceUpdate(LoginRequiredMixin, UpdateView):
     button_label = _('Update Service')
-    form_class = forms.ServiceForm
+    form_class = forms.ServiceUpdate
     model = models.Service
     template_name = 'promgen/service_form.html'
 
@@ -706,7 +706,7 @@ class RuleRegister(LoginRequiredMixin, FormView, ServiceMixin):
 
 class ServiceRegister(LoginRequiredMixin, FormView):
     button_label = _('Service Register')
-    form_class = forms.ProjectForm
+    form_class = forms.ServiceRegister
     model = models.Service
     template_name = 'promgen/service_form.html'
 


### PR DESCRIPTION
* Rename to fix descriptions
 - ServiceForm -> ServiceUpdate
 - ProjectMove -> ProjectUpdate
 - ProjectForm -> ProjectRegister
* Add missing ServiceRegister
* Fix ServiceRegister to use the correct ServiceRegister

Should fix #53 reported by @seoester