### PR TITLE
Temporarily disable pending refactoring

### DIFF
--- a/promgen/static/js/promgen.js
+++ b/promgen/static/js/promgen.js
@@ -157,6 +157,7 @@ $(document).ready(function() {
     }
   });
 
+/* Disable pending refactoring  
   $("select[data-ajax]").each(function(index) {
     var ele = $(this);
     var tgt = $(ele.data('target'));
@@ -172,6 +173,8 @@ $(document).ready(function() {
       tgt.typeahead({
         source: data.data,
         items: "all",
+        minLength: 3,
+        delay: 1,
         updater: function(item) {
           return item + ele.data("append")
         }
@@ -185,6 +188,7 @@ $(document).ready(function() {
     });
 
   });
+*/
 
   $('[data-filter]').change(function(){
     var search = this.value.toUpperCase();

--- a/promgen/templates/promgen/rule_form_block.html
+++ b/promgen/templates/promgen/rule_form_block.html
@@ -62,6 +62,7 @@
     {% include 'promgen/error_block.html' with errors=form.clause.errors only %}
     {{ form.clause }}
   </div>
+<!-- Disable pending refactoring
   <div class="panel-body">
       <select
         data-target="#id_clause"
@@ -72,6 +73,7 @@
         <option value="">- insert metric at cursor -</option>
       </select>
   </div>
+-->
   <div class="panel-body">
     <a
       class="btn btn-primary btn-sm"


### PR DESCRIPTION
When proxying over several prometheus servers, this can cause the rule
editor to slow down the entire page. While it's annoying to remove
features, it's probably simplest to disable this feature for a single
release until there's more time to implement it in a better way.

I hope to bring this back soon, but want to disable this so I can cut a new version