### PR TITLE
Show warning when parent rule is missing <exclude> macro

### DIFF
--- a/promgen/static/css/promgen.css
+++ b/promgen/static/css/promgen.css
@@ -8,7 +8,7 @@
 }
 
 /* https://stackoverflow.com/questions/5379752/css-style-external-links */
-a[href*="//"]:after {
+a[rel]:after {
   content: " " url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAVklEQVR4Xn3PgQkAMQhDUXfqTu7kTtkpd5RA8AInfArtQ2iRXFWT2QedAfttj2FsPIOE1eCOlEuoWWjgzYaB/IkeGOrxXhqB+uA9Bfcm0lAZuh+YIeAD+cAqSz4kCMUAAAAASUVORK5CYII=);
 }
 

--- a/promgen/templates/base.html
+++ b/promgen/templates/base.html
@@ -49,7 +49,7 @@
                           <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Links <span class="caret"></span></a>
                           <ul class="dropdown-menu">
                             {% for title, link in EXTERNAL_LINKS.items %}
-                            <li><a href="{{ link }}">{{ title }}</a></li>
+                            <li><a rel="noopener noreferrer" href="{{ link }}">{{ title }}</a></li>
                             {% endfor %}
                           </ul>
                         </li>

--- a/promgen/templates/promgen/ajax_clause_check.html
+++ b/promgen/templates/promgen/ajax_clause_check.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 {% load promgen %}
-<div id="ajax-clause-check" class="panel panel-default">
+<div id="ajax-clause-check" class="panel panel-info">
   <div class="panel-heading">Query Result</div>
   <div class="panel-body">
   <p>Query Duration: {{ duration }}</p>

--- a/promgen/templates/promgen/rule_form_block.html
+++ b/promgen/templates/promgen/rule_form_block.html
@@ -41,8 +41,21 @@
       <li><a rel="noopener noreferrer" href="https://prometheus.io/docs/querying/functions/">Functions</a></li>
       <li><a rel="noopener noreferrer" href="https://prometheus.io/docs/querying/examples/">Examples</a></li>
       <li>Promgen:</li>
-      <li><a rel="noopener noreferrer" href="https://promgen.readthedocs.io/en/latest/rules.html">Rules</a></li>
+      <li><a rel="noopener noreferrer" href="https://promgen.readthedocs.io/en/latest/user/rules.html">Rules</a></li>
     </ul>
+
+    {% if rule.parent %}
+    {% if 'macro' not in rule.parent.clause %}
+    <div class="alert alert-warning" role="alert">
+      <span class="glyphicon glyphicon-alert" aria-hidden="true"></span>
+      <span class="sr-only">Warning:</span>
+      Missing Macro in parent rule. Please add
+      <a rel="noopener noreferrer" class="alert-link" href="https://promgen.readthedocs.io/en/latest/user/rules.html">{{ macro }}</a>
+      macro to parent rule
+    </div>
+    {% endif %}
+    {% endif %}
+
     <ul class="list-inline">
       <li>Example Query</li>
       <li>

--- a/promgen/templates/promgen/rule_form_block.html
+++ b/promgen/templates/promgen/rule_form_block.html
@@ -26,13 +26,7 @@
     {{ form.description }}
     <p class="help-block">This description is not used by Prometheus. It is for Developer's to add aditional context only</p>
   </div>
-</div>
-
-<div class="panel panel-primary">
-  <div class="panel-heading">
-    {{ form.clause.label_tag }}
-  </div>
-
+  <div class="panel-heading">{{ form.clause.label_tag }}</div>
   <div class="panel-body">
     <ul class="list-inline">
       <li>Prometheus:</li>
@@ -45,20 +39,21 @@
     </ul>
 
     {% if rule.parent %}
-    {% if 'macro' not in rule.parent.clause %}
+
+    {% if macro not in rule.parent.clause %}
     <div class="alert alert-warning" role="alert">
       <span class="glyphicon glyphicon-alert" aria-hidden="true"></span>
       <span class="sr-only">Warning:</span>
-      Missing Macro in parent rule. Please add
-      <a rel="noopener noreferrer" class="alert-link" href="https://promgen.readthedocs.io/en/latest/user/rules.html">{{ macro }}</a>
-      macro to parent rule
+      Missing <strong>{{ macro }}</strong> macro in parent rule. Please reffer to Promgen's documentation regarding
+      <a rel="noopener noreferrer" class="alert-link" href="https://promgen.readthedocs.io/en/latest/user/rules.html">rule overrides</a>
     </div>
     {% endif %}
+
     {% endif %}
 
-    <ul class="list-inline">
-      <li>Example Query</li>
-      <li>
+    <dl class="list-inline">
+      <dt>Example Query</dt>
+      <dd>
         <code
           data-href="{% url 'rule-test' rule.id %}"
           data-source="self"
@@ -68,8 +63,24 @@
           >
           node_load1{% templatetag openbrace %}{{rule.content_type.model}}="{{ rule.content_object.name }}", {{ macro }}} > 5
         </code>
-      </li>
-    </ul>
+      </dd>
+{% if rule.parent %}
+      <dt>
+        <a href="{% url 'rule-edit' rule.parent.pk %}" />Parent Query</a>
+      </dt>
+      <dd>
+        <code
+          data-href="{% url 'rule-test' rule.id %}"
+          data-source="self"
+          data-target="#ajax-clause-check"
+          data-content_type="{{rule.content_type.name}}"
+          data-object_id="{{rule.object_id}}"
+          >
+          {{rule.parent.clause}}
+        </code>
+      </dd>
+{% endif %}
+    </dl>
   </div>
   <div class="panel-body">
     {% include 'promgen/error_block.html' with errors=form.clause.errors only %}

--- a/promgen/templates/promgen/rule_update.html
+++ b/promgen/templates/promgen/rule_update.html
@@ -17,50 +17,6 @@ Promgen / Rule / {{ rule.name }}
   <table class="table table-bordered table-condensed"></table>
 </div>
 
-{% if rule.parent %}
-<div class="panel panel-default">
-  <div class="panel-heading">
-    <button class="btn btn-default" type="button" data-toggle="collapse" data-target="#rule-parent" aria-expanded="false" aria-controls="collapseExample">
-      Parent Rule
-    </button>
-    <a class="btn btn-default" href="{% url 'rule-edit' rule.parent.pk %}" />Edit Parent</a>
-  </div>
-  <div id="rule-parent" class="panel-body collapse">
-    <pre>{% include "promgen/prometheus.rule" %}</pre>
-    <input id="parent-clause" type="hidden" value="{{rule.parent.clause}}">
-    <a
-      class="btn btn-primary btn-sm"
-      data-href="{% url 'rule-test' rule.parent.id %}"
-      data-source="#parent-clause"
-      data-target="#ajax-clause-check"
-      >Test Parent</a>
-  </div>
-</div>
-{% endif %}
-
-{% if rule.overrides.count %}
-  <div class="panel panel-default">
-    <div class="panel-heading">
-      <button class="btn btn-default" type="button" data-toggle="collapse" data-target="#rule-children" aria-expanded="false" aria-controls="collapseExample">
-        Overridden By
-      </button>
-    </div>
-    <table class="table collapse" id="rule-children">
-  {% for r in rule.overrides.all %}
-      <tr>
-        <td class="col-xs-2"><a href="{{ r.content_object.get_absolute_url }}">{{ r.content_object }}</a></td>
-        <td class="col-xs-2"><a href="{% url 'rule-edit' r.pk %}">{{ r.name }}</a></td>
-        <td class="col-xs-8">
-          <code data-href="{% url 'rule-test' r.id %}" data-source="self" data-target="#ajax-clause-check">
-            {{ r.clause|rulemacro:r }}
-          </code>
-        </td>
-      </tr>
-  {% endfor %}
-    </table>
-  </div>
-{% endif %}
-
 <form action="{% url 'rule-edit' rule.pk %}" class="input-group" method="post">{% csrf_token %}
 <div class="row">
 
@@ -127,8 +83,30 @@ Promgen / Rule / {{ rule.name }}
       </li>
     </ul>
   </div>
-</div>
-</div>
+
+</div><!-- end col -->
+</div><!-- end row -->
+
+{% if rule.overrides.count %}
+  <div class="panel panel-default">
+    <div class="panel-heading">
+        Child Rules
+    </div>
+    <table class="table">
+  {% for r in rule.overrides.all %}
+      <tr>
+        <td class="col-xs-2"><a href="{{ r.content_object.get_absolute_url }}">{{ r.content_object }}</a></td>
+        <td class="col-xs-2"><a href="{% url 'rule-edit' r.pk %}">{{ r.name }}</a></td>
+        <td class="col-xs-8">
+          <code data-href="{% url 'rule-test' r.id %}" data-source="self" data-target="#ajax-clause-check">
+            {{ r.clause|rulemacro:r }}
+          </code>
+        </td>
+      </tr>
+  {% endfor %}
+    </table>
+  </div>
+{% endif %}
 
 <div class="panel panel-primary">
   <div class="panel-body">


### PR DESCRIPTION
![2018-04-05 11 16 22](https://user-images.githubusercontent.com/89725/38344146-e0acca4a-38c2-11e8-9dc1-f6c8d98141e4.png)
This should help reduce a bit of confusion when dealing with rule overrides