### PR TITLE
Update Celery to 4.1.1

### DIFF
--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -1,5 +1,5 @@
 atomicwrites==1.1.5
-celery==4.1.0
+celery==4.1.1
 dj-database-url
 django_nose
 Django==1.11.6

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     ],
     install_requires=[
         'atomicwrites',
-        'celery[redis]==4.1.0',
+        'celery[redis]==4.1.1',
         'dj-database-url',
         'Django >= 1.11, < 1.12',
         'envdir',


### PR DESCRIPTION
Fixes errors from rename of kombu.async to kombu.asynchronous