### PR TITLE
Parameterise docker-compose-bootstrap using env vars

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -9,13 +9,21 @@ fi
 case "$1" in
 docker-compose-bootstrap)
   # Shortcut to wait for database to startup and run migrations
+
+  # These env vars are used as parameters when registering a new shard.
+  # Set defaults:
+  : "${PROMGEN_REGISTER_SHARD:=docker-demo}"
+  : "${PROMGEN_REGISTER_HOST:=prometheus}"
+  : "${PROMGEN_REGISTER_PORT:=9090}"
+
   until promgen check 2>/dev/null
   do
     echo "Waiting for database to startup"
     sleep 3
   done
+
   promgen migrate
-  promgen register docker-demo prometheus 9090
+  promgen register "${PROMGEN_REGISTER_SHARD}" "${PROMGEN_REGISTER_HOST}" "${PROMGEN_REGISTER_PORT}"
   exit 0
   ;;
 worker)


### PR DESCRIPTION
This PR adds parameters via env variables to the `docker-compose-bootstrap` shortcut command.

This enables setting the values in the `environment` stanza of a docker-compose file.