### PR TITLE
Fix for missing promtool validation error

### DIFF
--- a/promgen/prometheus.py
+++ b/promgen/prometheus.py
@@ -55,7 +55,7 @@ def check_rules(rules):
         try:
             subprocess.check_output(cmd, stderr=subprocess.STDOUT)
         except subprocess.CalledProcessError as e:
-            raise Exception(rendered + e.output.decode('utf8'))
+            raise Exception(rendered.decode('utf8') + e.output.decode('utf8'))
 
 
 def render_rules(rules=None, version=None):

--- a/promgen/templates/promgen/rule_update.html
+++ b/promgen/templates/promgen/rule_update.html
@@ -24,7 +24,7 @@ Promgen / Rule / {{ rule.name }}
   <div class="panel panel-danger">
     <div class="panel-heading">Errors</div>
       {% for error in form.non_field_errors %}
-        <div class="panel-body">{{ error|linebreaks }}</div>
+        <div class="panel-body"><pre>{{ error }}</pre></div>
       {% endfor %}
   </div>
   {% endif %}


### PR DESCRIPTION
Since our rendered yaml file is now utf8 encode, we need to make sure to
decode it when showing our exception