### PR TITLE
When a user subscribes, ensure they have a default notifier configured

### DIFF
--- a/promgen/views.py
+++ b/promgen/views.py
@@ -837,7 +837,8 @@ class ProjectNotifierRegister(LoginRequiredMixin, FormView, ProjectMixin):
 
     def form_valid(self, form):
         project = get_object_or_404(models.Project, id=self.kwargs['pk'])
-        sender, _ = models.Sender.get_or_create(obj=project, owner=self.request.user, **form.clean())
+        sender, created = models.Sender.get_or_create(obj=project, owner=self.request.user, **form.clean())
+        signals.check_user_subscription(models.Sender, sender, created, self.request)
         return HttpResponseRedirect(project.get_absolute_url())
 
 
@@ -848,7 +849,8 @@ class ServiceNotifierRegister(LoginRequiredMixin, FormView, ServiceMixin):
 
     def form_valid(self, form):
         service = get_object_or_404(models.Service, id=self.kwargs['pk'])
-        sender, _ = models.Sender.get_or_create(obj=service, owner=self.request.user, **form.clean())
+        sender, created = models.Sender.get_or_create(obj=service, owner=self.request.user, **form.clean())
+        signals.check_user_subscription(models.Sender, sender, created, self.request)
         return HttpResponseRedirect(service.get_absolute_url())
 
 


### PR DESCRIPTION
This should reduce confusion if a user subscribes to a project/service but does not already have notifications subscribe. It will default to using owner.email to create a notification or print a warning if it does not exist