### PR TITLE
[BUGFIX] Move promtool validation into RuleForm.clean

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,13 @@ jobs:
           SECRET_KEY: abcd
     steps:
       - checkout
+      - run:
+          name: Fetch Promtool
+          command: |
+            sudo mkdir -p /usr/local/bin
+            curl -L -s https://github.com/prometheus/prometheus/releases/download/v2.8.1/prometheus-2.8.1.linux-amd64.tar.gz |\
+            sudo tar -xz -C /usr/local/bin --strip-components=1 prometheus-2.8.1.linux-amd64/promtool
+            sudo chmod +x /usr/local/bin/promtool
       - run: pipenv install --dev
       - run: pipenv run promgen test
       - run: pipenv run coverage html -d test-results

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.6.4-alpine
 MAINTAINER paul.traylor@linecorp.com
 
-ENV PROMETHEUS_VERSION 2.1.0
+ENV PROMETHEUS_VERSION 2.8.1
 ENV PROMETHEUS_DOWNLOAD_URL https://github.com/prometheus/prometheus/releases/download/v${PROMETHEUS_VERSION}/prometheus-${PROMETHEUS_VERSION}.linux-amd64.tar.gz
 
 RUN adduser -D -u 1000 promgen promgen

--- a/promgen/forms.py
+++ b/promgen/forms.py
@@ -3,7 +3,7 @@
 
 from django import forms
 from dateutil import parser
-from promgen import models, plugins, validators
+from promgen import models, plugins, prometheus, validators
 
 
 class ImportConfigForm(forms.Form):
@@ -113,19 +113,6 @@ class URLForm(forms.ModelForm):
         exclude = ['project']
 
 
-class NewRuleForm(forms.ModelForm):
-    class Meta:
-        model = models.Rule
-        exclude = ['content_type', 'object_id', 'parent']
-        widgets = {
-            'name': forms.TextInput(attrs={'class': 'form-control'}),
-            'duration': forms.TextInput(attrs={'class': 'form-control'}),
-            'clause': forms.Textarea(attrs={'rows': 5, 'class': 'form-control'}),
-            'enabled': forms.CheckboxInput(attrs={'data-toggle': 'toggle', 'data-size': 'mini'}),
-            'description': forms.Textarea(attrs={'rows': 5, 'class': 'form-control'}),
-        }
-
-
 class RuleForm(forms.ModelForm):
     class Meta:
         model = models.Rule
@@ -137,6 +124,12 @@ class RuleForm(forms.ModelForm):
             'enabled': forms.CheckboxInput(attrs={'data-toggle': 'toggle', 'data-size': 'mini'}),
             'description': forms.Textarea(attrs={'rows': 5, 'class': 'form-control'}),
         }
+
+    def clean(self):
+        # Check our cleaned data then let Prometheus check our rule
+        super().clean()
+        rule = models.Rule(**self.cleaned_data)
+        prometheus.check_rules([rule])
 
 
 class RuleCopyForm(forms.Form):

--- a/promgen/prometheus.py
+++ b/promgen/prometheus.py
@@ -55,7 +55,7 @@ def check_rules(rules):
         try:
             subprocess.check_output(cmd, stderr=subprocess.STDOUT)
         except subprocess.CalledProcessError as e:
-            raise Exception(rendered.decode('utf8') + e.output.decode('utf8'))
+            raise ValidationError(rendered.decode('utf8') + e.output.decode('utf8'))
 
 
 def render_rules(rules=None, version=None):
@@ -452,4 +452,3 @@ def silence(labels, duration=None, **kwargs):
     response = util.post(url, json=kwargs)
     response.raise_for_status()
     return response
-    

--- a/promgen/templates/promgen/rule_update.html
+++ b/promgen/templates/promgen/rule_update.html
@@ -30,7 +30,7 @@ Promgen / Rule / {{ rule.name }}
   <div class="panel panel-danger">
     <div class="panel-heading">Errors</div>
       {% for error in form.non_field_errors %}
-        <div class="panel-body"><pre>{{ error }}</pre></div>
+        <div class="panel-body" v-pre><pre>{{ error }}</pre></div>
       {% endfor %}
   </div>
   {% endif %}

--- a/promgen/tests/test_rules.py
+++ b/promgen/tests/test_rules.py
@@ -3,13 +3,14 @@
 
 from unittest import mock
 
-from django.contrib.auth.models import User, Permission
-from django.urls import reverse
-
 import promgen.templatetags.promgen as macro
-from django.core.exceptions import ValidationError
 from promgen import models, prometheus
 from promgen.tests import PromgenTest
+
+from django.contrib.auth.models import Permission, User
+from django.core.exceptions import ValidationError
+from django.test import override_settings
+from django.urls import reverse
 
 _RULES = '''
 ALERT RuleName
@@ -34,6 +35,8 @@ groups:
     labels:
       severity: severe
 '''.lstrip().encode('utf-8')
+
+TEST_SETTINGS = PromgenTest.data_yaml('examples', 'promgen.yml')
 
 
 class RuleTest(PromgenTest):
@@ -134,6 +137,7 @@ class RuleTest(PromgenTest):
         for k, r in rules.items():
             self.assertEquals(macro.rulemacro(r['model'].clause, r['model']), r['assert'], 'Expansion wrong for %s' % k)
 
+    @override_settings(PROMGEN=TEST_SETTINGS)
     @mock.patch('django.dispatch.dispatcher.Signal.send')
     def test_invalid_annotation(self, mock_post):
         # $label.foo is invalid (should be $labels) so make sure we raise an exception

--- a/promgen/tests/test_rules.py
+++ b/promgen/tests/test_rules.py
@@ -7,9 +7,9 @@ from django.contrib.auth.models import User, Permission
 from django.urls import reverse
 
 import promgen.templatetags.promgen as macro
+from django.core.exceptions import ValidationError
 from promgen import models, prometheus
 from promgen.tests import PromgenTest
-
 
 _RULES = '''
 ALERT RuleName
@@ -138,6 +138,5 @@ class RuleTest(PromgenTest):
     def test_invalid_annotation(self, mock_post):
         # $label.foo is invalid (should be $labels) so make sure we raise an exception
         models.RuleAnnotation.objects.create(name='summary', value='{{$label.foo}}', rule=self.rule)
-        with self.assertRaises(Exception):
+        with self.assertRaises(ValidationError):
             prometheus.check_rules([self.rule])
-

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,4 +11,7 @@ exclude = migrations
 
 [isort]
 not_skip = __init__.py
-known_first_party = promgen
+forced_separate=django,promgen
+know_django=django
+known_first_party=promgen
+sections=FUTURE,STDLIB,DJANGO,THIRDPARTY,FIRSTPARTY,LOCALFOLDER


### PR DESCRIPTION
Removes some duplicated code and consolidates the promtool rule validation into a single place for more consistent error handling