### PR TITLE
When listing rules, show rule specific labels

### DIFF
--- a/promgen/templates/promgen/alert_row.html
+++ b/promgen/templates/promgen/alert_row.html
@@ -10,7 +10,7 @@
         <dd>
             <ul class="list-inline">
                 <li v-for="(value, label, index) in alert.labels">
-                    <a @click.prevent="silenceAppendLabel" class="label label-warning" :data-label="label" :data-value="value">{{label}}:{{value}}</a>
+                    <a @click.prevent="silenceAppendLabel" class="label label-danger" :data-label="label" :data-value="value">{{label}}:{{value}}</a>
                 </li>
             </ul>
         </dd>

--- a/promgen/templates/promgen/rule_block.html
+++ b/promgen/templates/promgen/rule_block.html
@@ -3,19 +3,19 @@
 {% for rule in rule_list %}
 <tr {% if collapse %}class="active collapse {{ collapse }}{{overwrite_id}}" {% endif %}>
   <td>
-    <a href="{% url 'rule-edit' rule.id %}">{{ rule.name }}</a>
+    <a title="{{rule.description}}" data-toggle="tooltip" data-placement="right" href="{% url 'rule-edit' rule.id %}">{{ rule.name }}</a>
     {% if rule.parent %}
-    <a class="pull-right" title="{% trans "View Parent" %}" href="{% url 'rule-edit' rule.parent.id %}" data-toggle="tooltip" data-placement="right">
+    <a class="pull-right" title="{% trans "View Parent" %}" href="{% url 'rule-edit' rule.parent.id %}">
       <span class="glyphicon glyphicon-upload"></span>
     </a>
     {% endif %}
+    <ul>
+      {% for k,v in rule.labels.items|dictsort:0 %}
+      <li class="label label-warning">{{k}}:{{v}}</li>
+      {% endfor %}
+    </ul>
   </td>
-  <td {% if not rule.enabled %}class="bg-disabled text-muted" {% endif %} style="word-break: break-word;">
-    {{ rule.clause }}
-    {% if rule.description %}
-    <span title="{{rule.description}}" data-toggle="tooltip" data-placement="right" class="glyphicon glyphicon-question-sign pull-right" aria-hidden="true"></span>
-    {% endif %}
-  </td>
+  <td {% if not rule.enabled %}class="bg-disabled text-muted" {% endif %} style="word-break: break-word;">{{ rule.clause }}</td>
 
   <td>{{ rule.duration }}</td>
 

--- a/promgen/templates/promgen/rule_block.html
+++ b/promgen/templates/promgen/rule_block.html
@@ -11,7 +11,7 @@
     {% endif %}
     <ul>
       {% for k,v in rule.labels.items|dictsort:0 %}
-      <li class="label label-warning">{{k}}:{{v}}</li>
+      <li class="label label-primary">{{k}}:{{v}}</li>
       {% endfor %}
     </ul>
   </td>


### PR DESCRIPTION
- When listing rules, show rule specific labels
- Labels on Rule settings colored as -primary
- Labels on Alerts colored as -danger
- Labels on Silences colored as -warning