### PR TITLE
Add silence button to blackbox exporter entries

### DIFF
--- a/docker/prometheus.yml
+++ b/docker/prometheus.yml
@@ -33,8 +33,6 @@ scrape_configs:
 
   - job_name: 'blackbox'
     metrics_path: /probe
-    params:
-      module: [http_2xx]  # Look for a HTTP 200 response.
     file_sd_configs:
       - files:
         - "/etc/prometheus/blackbox.json"

--- a/promgen/prometheus.py
+++ b/promgen/prometheus.py
@@ -119,7 +119,7 @@ def render_urls():
             "labels": {
                 "project": k[0],
                 "service": k[1],
-                "module": k[3],
+                "job": k[3],
                 "__shard": k[2],
                 "__param_module": k[3],
             },

--- a/promgen/prometheus.py
+++ b/promgen/prometheus.py
@@ -119,6 +119,7 @@ def render_urls():
             "labels": {
                 "project": k[0],
                 "service": k[1],
+                "module": k[3],
                 "__shard": k[2],
                 "__param_module": k[3],
             },

--- a/promgen/templates/promgen/project_detail_urls.html
+++ b/promgen/templates/promgen/project_detail_urls.html
@@ -5,6 +5,7 @@
     <tr>
       <th>URL</th>
       <th>Probe</th>
+      <th>Silence</th>
       <th>&nbsp;</th>
     </tr>
     {% for url in project.url_set.all %}
@@ -12,7 +13,16 @@
       <td>{{ url.url }}</td>
       <td title="{{ url.probe.description }}">{{ url.probe.module }}</td>
       <td>
-        <form method="post" action="{% url 'url-delete' url.id %}" onsubmit="return confirm('Delete this url?')" style="display: inline">
+        <a @click.prevent="silenceSetLabels"
+          class="btn btn-warning btn-xs"
+          data-module="{{url.probe.module}}"
+          data-instance="{{url.url}}">{% trans "Silence" %}</a>
+      </td>
+      <td>
+        <form method="post"
+          action="{% url 'url-delete' url.id %}"
+          onsubmit="return confirm('Delete this url?')"
+          style="display: inline">
           {% csrf_token %}
           <button class="btn btn-danger btn-xs">{% trans "Delete" %}</button>
         </form>

--- a/promgen/templates/promgen/project_detail_urls.html
+++ b/promgen/templates/promgen/project_detail_urls.html
@@ -15,7 +15,7 @@
       <td>
         <a @click.prevent="silenceSetLabels"
           class="btn btn-warning btn-xs"
-          data-module="{{url.probe.module}}"
+          data-job="{{url.probe.module}}"
           data-instance="{{url.url}}">{% trans "Silence" %}</a>
       </td>
       <td>


### PR DESCRIPTION
Use the `module` as a `job` label, to better match exporters, and use the combination of `job` and `instance` to allow muting a `blackbox_exporter` probe