### PR TITLE
[BUGFIX] pk should always be an integer

### DIFF
--- a/promgen/views.py
+++ b/promgen/views.py
@@ -1225,7 +1225,7 @@ class Import(PromgenPermissionMixin, FormView):
 
 class RuleTest(LoginRequiredMixin, View):
     def post(self, request, pk):
-        if pk == '0':
+        if pk == 0:
             rule = models.Rule()
             rule.set_object(request.POST['content_type'], request.POST['object_id'])
         else:


### PR DESCRIPTION
While the route was updated in #167, this check was never updated

Fixes #177