### PR TITLE
Change stdout.write to stdout.buffer.write

### DIFF
--- a/promgen/management/commands/rules.py
+++ b/promgen/management/commands/rules.py
@@ -28,4 +28,4 @@ class Command(BaseCommand):
             # Since we're already working with utf8 encoded data, we can skip
             # the newline ending here
             self.stdout.ending = None
-            self.stdout.write(prometheus.render_rules())
+            self.stdout.buffer.write(prometheus.render_rules())


### PR DESCRIPTION
I found the following error when using ```promgen rules```.
```
$ promgen rules
Traceback (most recent call last):
  File "/Users/shokada/src/line/promgenenv/bin/promgen", line 11, in <module>
    load_entry_point('promgen', 'console_scripts', 'promgen')()
  File "/Users/shokada/src/line/promgen/promgen/manage.py", line 20, in main
    execute_from_command_line(sys.argv)
  File "/Users/shokada/src/line/promgenenv/lib/python3.7/site-packages/django/core/management/__init__.py", line 381, in execute_from_command_line
    utility.execute()
  File "/Users/shokada/src/line/promgenenv/lib/python3.7/site-packages/django/core/management/__init__.py", line 375, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/Users/shokada/src/line/promgenenv/lib/python3.7/site-packages/django/core/management/base.py", line 323, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/Users/shokada/src/line/promgenenv/lib/python3.7/site-packages/django/core/management/base.py", line 364, in execute
    output = self.handle(*args, **options)
  File "/Users/shokada/src/line/promgen/promgen/management/commands/rules.py", line 31, in handle
    self.stdout.write(prometheus.render_rules())
  File "/Users/shokada/src/line/promgenenv/lib/python3.7/site-packages/django/core/management/base.py", line 145, in write
    self._out.write(style_func(msg))
TypeError: write() argument must be str, not bytes
```

The cause of this error is that ```Command.handle``` in ```rules.py``` uses ```stdout.write``` even though ```prometheus.render_rules``` returns a byte string.
To avoid this, I changed ```stdout.write``` to ```stdout.buffer.write```.

Thanks.