### PR TITLE
[BUGFIX] Rule.content_object should use our Site proxy module

### DIFF
--- a/promgen/models.py
+++ b/promgen/models.py
@@ -390,7 +390,7 @@ class Rule(models.Model):
         models.Q(app_label='promgen', model='service'))
     )
     object_id = models.PositiveIntegerField()
-    content_object = GenericForeignKey('content_type', 'object_id')
+    content_object = GenericForeignKey('content_type', 'object_id', for_concrete_model=False)
     description = models.TextField(blank=True)
 
     class Meta:


### PR DESCRIPTION
Since we define most of our relations on our local proxy Site module,
we want to ensure our lookup does the same.