### PR TITLE
[INTERNAL] Refactored rule rendering to use Renderer and Serializer classes

### DIFF
--- a/promgen/prometheus.py
+++ b/promgen/prometheus.py
@@ -65,16 +65,6 @@ def render_rules(rules=None):
     if rules is None:
         rules = models.Rule.objects.filter(enabled=True)
 
-    prefetch_related_objects(
-        rules,
-        'content_object',
-        'content_type',
-        'overrides__content_object',
-        'overrides__content_type',
-        'ruleannotation_set',
-        'rulelabel_set',
-    )
-
     return renderers.RuleRenderer().render(
         serializers.AlertRuleSerializer(rules, many=True).data
     )

--- a/promgen/renderers.py
+++ b/promgen/renderers.py
@@ -1,0 +1,24 @@
+import yaml
+from rest_framework import renderers
+
+
+# https://www.django-rest-framework.org/api-guide/renderers/#custom-renderers
+class RuleRenderer(renderers.BaseRenderer):
+    format = "yaml"
+    media_type = "application/x-yaml"
+    charset = "utf-8"
+
+    def render(self, data, media_type=None, renderer_context=None):
+        # If this is a 'real' request, then we'll add a header so
+        # that we get a friendly name with our downloaded file
+        if renderer_context and "response" in renderer_context:
+            renderer_context["response"][
+                "Content-Disposition"
+            ] = "attachment; filename=promgen.rule.yml"
+
+        return yaml.safe_dump(
+            {"groups": [{"name": name, "rules": data[name]} for name in data]},
+            default_flow_style=False,
+            allow_unicode=True,
+            encoding=self.charset,
+        )

--- a/promgen/serializers.py
+++ b/promgen/serializers.py
@@ -1,5 +1,9 @@
-from promgen import models, shortcuts
+import collections
+
 from rest_framework import serializers
+
+import promgen.templatetags.promgen as macro
+from promgen import models, shortcuts
 
 
 class WebLinkField(serializers.Field):
@@ -48,4 +52,34 @@ class SenderSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = models.Sender
-        fields = ('sender', 'owner', 'label')
+
+
+class AlertRuleList(serializers.ListSerializer):
+    def to_representation(self, data):
+        grouped_list = collections.defaultdict(list)
+        for item in data:
+            data = self.child.to_representation(item)
+            grouped_list[str(item.content_object)].append(data)
+        return grouped_list
+
+    @property
+    def data(self):
+        if not hasattr(self, "_data"):
+            self._data = self.to_representation(self.instance)
+        return serializers.ReturnDict(self._data, serializer=self)
+
+
+class AlertRuleSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = models.Rule
+        fields = ("alert", "expr", "for", "labels", "annotations")
+        list_serializer_class = AlertRuleList
+
+    def to_representation(self, obj):
+        return {
+            "alert": obj.name,
+            "expr": macro.rulemacro(obj),
+            "for": obj.duration,
+            "labels": obj.labels,
+            "annotations": obj.annotations,
+        }


### PR DESCRIPTION
Refactor to use rest_framework Serializer so that we can better consolidate our logic for rendering (and prefetching) a list of Rule objects and rendering them in the correct format