### PR TITLE
Change minimum coverage ratio.

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 0%
+    patch:
+      default:
+        target: 0%

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,5 @@
+# The codecov report is sometimes useful as a glance to see how much is being covered,
+# but we do not want it to fail our pull request because of it so change minimum coverage ratio to 0%.
 coverage:
   status:
     project:


### PR DESCRIPTION
The codecov report is sometimes useful as a glance to see how much is being covered, but we do not want it to fail our pull request because of it so change minimum coverage ratio to 0%.
https://docs.codecov.io/docs/commit-status#section-target
