### PR TITLE
[INTERNAL] Start refactoring api into `/rest/` namespace

### DIFF
--- a/promgen/rest.py
+++ b/promgen/rest.py
@@ -1,13 +1,25 @@
 # Copyright (c) 2019 LINE Corporation
 # These sources are released under the terms of the MIT license: see LICENSE
 
-from rest_framework import viewsets
+from rest_framework import permissions, viewsets
 from rest_framework.decorators import action
 from rest_framework.response import Response
 
 from django.http import HttpResponse
 
 from promgen import filters, models, prometheus, renderers, serializers
+
+
+class AllViewSet(viewsets.ViewSet):
+    permission_classes = [permissions.AllowAny]
+
+    @action(detail=False, methods=["get"], renderer_classes=[renderers.RuleRenderer])
+    def rules(self, request):
+        rules = models.Rule.objects.filter(enabled=True)
+        return Response(
+            serializers.AlertRuleSerializer(rules, many=True).data,
+            headers={"Content-Disposition": "attachment; filename=alert.rule.yml"},
+        )
 
 
 class ShardViewSet(viewsets.ModelViewSet):

--- a/promgen/templates/promgen/navbar.html
+++ b/promgen/templates/promgen/navbar.html
@@ -35,7 +35,7 @@
 
                         <li><a href="{% url 'api:api-root' %}">API</a></li>
                         <li><a href="{% url 'config-targets' %}">Export Targets</a></li>
-                        <li><a href="{% url 'config-rules' %}">Export Rules</a></li>
+                        <li><a href="{% url 'api:all-rules' %}">Export Rules</a></li>
                         <li><a href="{% url 'config-urls' %}">Export URL</a></li>
 
                         {% if EXTERNAL_LINKS %}

--- a/promgen/urls.py
+++ b/promgen/urls.py
@@ -24,9 +24,10 @@ from promgen import proxy, rest, views
 from rest_framework import routers
 
 router = routers.DefaultRouter()
-router.register('service', rest.ServiceViewSet)
-router.register('shard', rest.ShardViewSet)
-router.register('project', rest.ProjectViewSet)
+router.register("all", rest.AllViewSet, basename="all")
+router.register("service", rest.ServiceViewSet)
+router.register("shard", rest.ShardViewSet)
+router.register("project", rest.ProjectViewSet)
 
 
 urlpatterns = [
@@ -104,14 +105,12 @@ urlpatterns = [
     url('', include('django.contrib.auth.urls')),
     url('', include('social_django.urls', namespace='social')),
 
-    # Public API
-
     # Legacy API
     path('api/v1/config', csrf_exempt(views.ApiConfig.as_view())),
+    path("api/", include((router.urls, "api"), namespace="old-api")),
+    path('api/v1/rules', csrf_exempt(views.RulesConfig.as_view())),
 
-    # Promgen API
     path('api/v1/targets', csrf_exempt(views.ApiConfig.as_view()), name='config-targets'),
-    path('api/v1/rules', csrf_exempt(views.RulesConfig.as_view()), name='config-rules'),
     path('api/v1/urls', csrf_exempt(views.URLConfig.as_view()), name='config-urls'),
     path('api/v1/alerts', csrf_exempt(views.Alert.as_view()), name='alert'),
     path('api/v1/host/<slug>', views.HostDetail.as_view()),
@@ -131,7 +130,8 @@ urlpatterns = [
     path("proxy/v1/silences", csrf_exempt(proxy.ProxySilences.as_view()), name="proxy-silence"),
     path("proxy/v1/silences/<silence_id>", csrf_exempt(proxy.ProxyDeleteSilence.as_view()), name="proxy-silence-delete"),
 
-    path("api/", include((router.urls, "api"), namespace="api")),
+    # Promgen rest API
+    path("rest/", include((router.urls, "api"), namespace="api")),    
 ]
 
 try:


### PR DESCRIPTION
- Rename `/api` to `/rest` for Promgen specific endpoints
- Add `/rest/all/rules` to replace `/api/v1/rules` to export all rules