### PR TITLE
[BUGFIX] Add missing duration label to rules page

### DIFF
--- a/promgen/templates/promgen/rule_form_block.html
+++ b/promgen/templates/promgen/rule_form_block.html
@@ -7,9 +7,11 @@
     <br />
     {% include 'promgen/error_block.html' with warning=form.enabled.errors only %}
     {{ form.enabled.label_tag }}
+    <br />
     {{ form.enabled }}
     <br />
     {% include 'promgen/error_block.html' with warning=form.duration.errors only %}
+    {{ form.duration.label_tag }}
     {{ form.duration }}
     <p>
       Examples:


### PR DESCRIPTION
![スクリーンショット 2020-02-20 14 41 24](https://user-images.githubusercontent.com/89725/74904372-13a39c00-53ef-11ea-9a5a-4a66ccf4ad12.png)

Adds missing `duration` label and minor fix to formatting