### PR TITLE
[BUGFIX] Fix missing error message with duplicate Rule name

### DIFF
--- a/promgen/forms.py
+++ b/promgen/forms.py
@@ -36,6 +36,11 @@ class ImportRuleForm(forms.Form):
         widget=forms.FileInput(attrs={'class': 'form-control'}),
         required=False)
 
+    def clean(self):
+        if any(self.cleaned_data.values()):
+            return self.cleaned_data
+        raise forms.ValidationError("Must submit data or file")
+
 
 class SilenceForm(forms.Form):
 


### PR DESCRIPTION
RuleRegister is slightly overloaded so that if a regular Rule fails
validation, it tries again as an import. The Import form has two
optional fields so we were never returning the original duplicate name
error from the original Rule validation