### PR TITLE
Fix exporter test

### DIFF
--- a/promgen/templates/promgen/exporter_form.html
+++ b/promgen/templates/promgen/exporter_form.html
@@ -37,16 +37,9 @@
         <div class="panel-footer">
           <div class="input-group-btn">
             <button class="btn btn-primary">Register Exporter</button>
-            <exporter-test
-                           class="btn btn-info"
-                           {% if project.farm %}
-                           href="{% url 'exporter-scrape' project.farm.id %}"
-                           {% else %}
-                           title="Please assign farm to test"
-                           disabled
-                           {% endif %}
-                           form="#exporter_form"
-                           target="#exporterresult">{% trans "Test" %}</exporter-test>
+            <exporter-test class="btn btn-info" href="{% url 'exporter-scrape' project.id %}" target="#exporterresult">
+              {% trans "Test" %}
+            </exporter-test>
           </div>
         </div>
       </div>
@@ -67,16 +60,9 @@
           <input type="hidden" name="enabled" value="1" />
           <div class="input-group-btn">
             <button style="width:80%" class="btn btn-primary">Register {{ default.job }} :{{ default.port }}{{ default.path }}</button>
-            <exporter-test
-                           style="width:20%"
-                           class="btn btn-info"
-                           {% if project.farm %}
-                           href="{% url 'exporter-scrape' project.farm.id %}"
-                           {% else %}
-                           title="Please assign farm to test"
-                           disabled
-                           {% endif %}
-                           target="#exporterresult">{% trans "Test" %}</exporter-test>
+            <exporter-test class="btn btn-info" href="{% url 'exporter-scrape' project.id %}" target="#exporterresult">
+              {% trans "Test" %}
+            </exporter-test>
           </div>
         </form>
         {% endfor %}

--- a/promgen/templates/promgen/project_detail_exporters.html
+++ b/promgen/templates/promgen/project_detail_exporters.html
@@ -31,17 +31,9 @@
           <input type="hidden" name="scheme" value="{{ exporter.scheme }}" />
           <input type="hidden" name="port" value="{{ exporter.port }}" />
           <input type="hidden" name="path" value="{{ exporter.path }}" />
-          <exporter-test
-              class="btn btn-info btn-xs"
-              {% if project.farm %}
-              href="{% url 'exporter-scrape' project.farm.id %}"
-              {% else %}
-              title="Please assign farm to test"
-              disabled
-              {% endif %}
-              target="#exporterresult"
-              >{% trans "Test" %}</exporter-test>
-          </div>
+          <exporter-test class="btn btn-info btn-xs" href="{% url 'exporter-scrape' project.id %}" target="#exporterresult">
+            {% trans "Test" %}
+          </exporter-test>
         </form>
       </td>
       <td>

--- a/promgen/tests/test_routes.py
+++ b/promgen/tests/test_routes.py
@@ -80,8 +80,13 @@ class RouteTests(tests.PromgenTest):
 
     @mock.patch("promgen.util.get")
     def test_scrape(self, mock_get):
-        farm = models.Farm.objects.create(name="test_scrape")
+        shard = models.Shard.objects.create(name="test_scrape_shard")
+        service = models.Service.objects.create(name="test_scrape_service")
+        farm = models.Farm.objects.create(name="test_scrape_farm")
         farm.host_set.create(name="example.com")
+        project = models.Project.objects.create(
+            name="test_scrape_project", service=service, shard=shard, farm=farm
+        )
 
         # Uses the scrape target as the key, and the POST body that should
         # result in that URL
@@ -109,7 +114,7 @@ class RouteTests(tests.PromgenTest):
             # For each POST body, check to see that we generate and attempt to
             # scrape the correct URL
             response = self.client.post(
-                reverse("exporter-scrape", args=(farm.pk,)), body
+                reverse("exporter-scrape", kwargs={"pk": project.pk}), body
             )
             self.assertRoute(response, views.ExporterScrape, 200)
             self.assertEqual(mock_get.call_args[0][0], url)

--- a/promgen/urls.py
+++ b/promgen/urls.py
@@ -53,6 +53,7 @@ urlpatterns = [
     path('project/<int:pk>/newfarm', views.FarmRegister.as_view(), name='farm-new'),
     path('project/<int:pk>/exporter', views.ExporterRegister.as_view(), name='project-exporter'),
     path('project/<int:pk>/notifier', views.ProjectNotifierRegister.as_view(), name='project-notifier'),
+    path('project/<int:pk>/scrape', views.ExporterScrape.as_view(), name='exporter-scrape'),
 
     path('exporter/<int:pk>/delete', views.ExporterDelete.as_view(), name='exporter-delete'),
     path('exporter/<int:pk>/toggle', views.ExporterToggle.as_view(), name='exporter-toggle'),
@@ -63,7 +64,6 @@ urlpatterns = [
 
     path('farm', views.FarmList.as_view(), name='farm-list'),
     path('farm/<int:pk>', views.FarmDetail.as_view(), name='farm-detail'),
-    path('farm/<int:pk>/scrape', views.ExporterScrape.as_view(), name='exporter-scrape'),
     path('farm/<int:pk>/refresh', views.FarmRefresh.as_view(), name='farm-refresh'),
     path('farm/<int:pk>/hosts', views.HostRegister.as_view(), name='hosts-add'),
     path('farm/<int:pk>/update', views.FarmUpdate.as_view(), name='farm-update'),

--- a/promgen/views.py
+++ b/promgen/views.py
@@ -615,23 +615,18 @@ class ExporterRegister(LoginRequiredMixin, FormView, mixins.ProjectMixin):
         exporter, _ = models.Exporter.objects.get_or_create(project=project, **form.clean())
         return HttpResponseRedirect(reverse('project-detail', args=[project.id]))
 
-class ExporterScrape(LoginRequiredMixin, FormView):
+class ExporterScrape(LoginRequiredMixin, View):
     # TODO: Move to /rest/project/<slug>/scrape
-    form_class = forms.ExporterForm
-
-    def form_invalid(self, form):
-        return JsonResponse(
-            {"message": "Form Errors", "errors": form.errors}, status=400
-        )
-
-    def form_valid(self, form):
+    def post(self, request, pk):
         futures = []
-        farm = get_object_or_404(models.Farm, id=self.kwargs["pk"])
+        farm = get_object_or_404(models.Farm, project=pk)
+        # So we have a mutable dictionary
+        data = request.POST.dict()
 
         # The default __metrics_path__ for Prometheus is /metrics so we need to
         # manually add it here in the case it's not set for our test
-        if not form.cleaned_data["path"]:
-            form.cleaned_data["path"] = "/metrics"
+        if not data["path"]:
+            data["path"] = "/metrics"
 
         def query():
             with concurrent.futures.ThreadPoolExecutor(max_workers=20) as executor:
@@ -640,7 +635,7 @@ class ExporterScrape(LoginRequiredMixin, FormView):
                         executor.submit(
                             util.get,
                             "{scheme}://{host}:{port}{path}".format(
-                                host=host.name, **form.cleaned_data
+                                host=host.name, **data
                             ),
                         )
                     )
@@ -659,7 +654,10 @@ class ExporterScrape(LoginRequiredMixin, FormView):
                         logger.exception("Unknown Exception")
                         yield "Unknown URL", "Unknown error"
 
-        return JsonResponse(dict(query()))
+        try:
+            return JsonResponse(dict(query()))
+        except Exception as e:
+            return JsonResponse({"error": "Error with query %s" % e})
 
 
 class URLRegister(LoginRequiredMixin, FormView, mixins.ProjectMixin):


### PR DESCRIPTION
- Query based on project.id (instead of farm.id) for future refactoring
- Change from form to regular POST data to avoid extra validation confusion
- Simplify exporter-test button html