### PR TITLE
Fix unknown command error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ help:
 
 ${PIP_BIN}:
 	python3 -m venv .venv
-	${PIP_BIN} pip -U pip
+	${PIP_BIN} install -U pip
 
 ${APP_BIN}: ${PIP_BIN}
 	${PIP_BIN} install -r docker/requirements.txt


### PR DESCRIPTION
Fixed the following error.
```
$ make clean
Removing venv
Clearing dist files

$ make run
python3 -m venv .venv
.venv/bin/pip pip -U pip
ERROR: unknown command "pip"
make: *** [.venv/bin/pip] Error 1
```