### PR TITLE
Fix checks

### DIFF
--- a/promgen/checks.py
+++ b/promgen/checks.py
@@ -12,14 +12,19 @@ from promgen import models, util
 def sites(app_configs, **kwargs):
     if models.Site.objects.count() == 0:
         yield checks.Warning(
-            "Site not configured", hint="Missing django site configuration"
+            "Site not configured",
+            hint="Missing django site configuration",
+            id="promgen.W006",
         )
 
     for site in models.Site.objects.filter(
         pk=settings.SITE_ID, domain__in=["example.com"]
     ):
         yield checks.Warning(
-            "Site not configured", obj=site, hint="Please update from admin panel"
+            "Promgen is configured to example domain",
+            obj=site,
+            hint="Please update from admin page /admin/",
+            id="promgen.W007",
         )
 
 
@@ -27,9 +32,13 @@ def sites(app_configs, **kwargs):
 # @custom.register(checks.Tags.models)
 def shards(**kwargs):
     if models.Shard.objects.filter(enabled=True).count() == 0:
-        yield checks.Warning("Missing shards", hint="Ensure some shards are enabled")
+        yield checks.Warning(
+            "Missing shards", hint="Ensure some shards are enabled", id="promgen.W004"
+        )
     if models.Shard.objects.filter(proxy=True).count() == 0:
-        yield checks.Warning("No proxy shards", hint="Ensure some shards are enabled")
+        yield checks.Warning(
+            "No proxy shards", hint="Ensure some shards are enabled", id="promgen.W004"
+        )
 
 
 @checks.register("settings")
@@ -39,11 +48,12 @@ def directories(**kwargs):
             path = pathlib.Path(util.setting(key)).parent
         except TypeError:
             yield checks.Warning(
-                "Missing setting for %s in %s " % (key, settings.PROMGEN_CONFIG_FILE)
+                "Missing setting for %s in %s " % (key, settings.PROMGEN_CONFIG_FILE),
+                id="promgen.W001",
             )
         else:
             if not os.access(path, os.W_OK):
-                yield checks.Warning("Unable to write to %s" % path)
+                yield checks.Warning("Unable to write to %s" % path, id="promgen.W002")
 
 
 @checks.register("settings")
@@ -53,8 +63,9 @@ def promtool(**kwargs):
         path = pathlib.Path(util.setting(key))
     except TypeError:
         yield checks.Warning(
-            "Missing setting for %s in %s " % (key, settings.PROMGEN_CONFIG_FILE)
+            "Missing setting for %s in %s " % (key, settings.PROMGEN_CONFIG_FILE),
+            id="promgen.W001",
         )
     else:
         if not os.access(path, os.X_OK):
-            yield checks.Warning("Unable to execute file %s" % path)
+            yield checks.Warning("Unable to execute file %s" % path, id="promgen.W003")

--- a/promgen/checks.py
+++ b/promgen/checks.py
@@ -7,22 +7,24 @@ from django.core import checks
 from promgen import models, util
 
 
-@checks.register(checks.Tags.models)
+# See notes in bootstrap.py
+# @custom.register(checks.Tags.models)
 def sites(app_configs, **kwargs):
     if models.Site.objects.count() == 0:
-        yield checks.Error(
+        yield checks.Warning(
             "Site not configured", hint="Missing django site configuration"
         )
 
     for site in models.Site.objects.filter(
         pk=settings.SITE_ID, domain__in=["example.com"]
     ):
-        yield checks.Error(
+        yield checks.Warning(
             "Site not configured", obj=site, hint="Please update from admin panel"
         )
 
 
-@checks.register(checks.Tags.models)
+# See notes in bootstrap.py
+# @custom.register(checks.Tags.models)
 def shards(**kwargs):
     if models.Shard.objects.filter(enabled=True).count() == 0:
         yield checks.Warning("Missing shards", hint="Ensure some shards are enabled")


### PR DESCRIPTION
The built in django [checks] framework runs automatically before many commands. This means that by default, they can't be used to check database objects, because they may be run pre-migrations. To solve this, we stop auto registering the checks that require database access, and only register them when we are specifically running our bootstrap scrip



[checks]: https://docs.djangoproject.com/en/3.0/topics/checks/#//apple_ref/Module/django.core.checks