### PR TITLE
Fix collectstatic in the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,10 +51,10 @@ COPY promgen/tests/examples/promgen.yml /etc/promgen/promgen.yml
 WORKDIR /usr/src/app
 RUN pip install --no-cache-dir -e .
 
+RUN SECRET_KEY=1 promgen collectstatic --noinput
+
 USER promgen
 EXPOSE 8000
-
-RUN SECRET_KEY=1 promgen collectstatic --noinput
 
 VOLUME ["/etc/promgen", "/etc/prometheus"]
 ENTRYPOINT ["/docker-entrypoint.sh"]


### PR DESCRIPTION
When collectstatic runs as `promgen` user it doesn't have access to dump files in `/root/.cache/promgen` (also not sure about the use of this directory)