### PR TITLE
[BUGFIXES] Use alternate Vue delimiters to fix double rendering bugs

### DIFF
--- a/promgen/static/js/promgen.vue.js
+++ b/promgen/static/js/promgen.vue.js
@@ -15,6 +15,7 @@ var dataStore = {
 
 var app = new Vue({
     el: '#vue',
+    delimiters: ['[[', ']]'],
     data: dataStore,
     methods: {
         toggleTarget: function (target) {

--- a/promgen/templates/base.html
+++ b/promgen/templates/base.html
@@ -39,28 +39,21 @@
   <script src="{% static "/js/promgen.vue.js" %}"></script>
   {% block javascript %}{% endblock %}
 
-
   <datalist style="display:none" id="common.labels">
-    <select>
-      <option>severity</option>
-    </select>
+    <option>severity</option>
   </datalist>
 
   <datalist style="display:none" id="common.annotations">
-    <select>
-      <option>summary</option>
-      <option>grafana</option>
-      <option>runbook</option>
-    </select>
+    <option>summary</option>
+    <option>grafana</option>
+    <option>runbook</option>
   </datalist>
 
   <datalist style="display:none" id="common.labels.severity">
-    <select>
-      <option>critical</option>
-      <option>major</option>
-      <option>minor</option>
-      <option>debug</option>
-    </select>
+    <option>critical</option>
+    <option>major</option>
+    <option>minor</option>
+    <option>debug</option>
   </datalist>
 </body>
 

--- a/promgen/templates/promgen/alert_row.html
+++ b/promgen/templates/promgen/alert_row.html
@@ -1,8 +1,7 @@
 {% load i18n %}
 
-{% verbatim %}
 <td class="col-xs-1">
-    <a :href="alert.generatorURL">{{alert.startsAt|time}}</a>
+    <a :href="alert.generatorURL">[[alert.startsAt|time]]</a>
 </td>
 <td>
     <dl class="dl-horizontal">
@@ -10,17 +9,16 @@
         <dd>
             <ul class="list-inline">
                 <li v-for="(value, label, index) in alert.labels">
-                    <a @click.prevent="silenceAppendLabel" class="label label-danger" :data-label="label" :data-value="value">{{label}}:{{value}}</a>
+                    <a @click.prevent="silenceAppendLabel" class="label label-danger" :data-label="label" :data-value="value">[[label]]:[[value]]</a>
                 </li>
             </ul>
         </dd>
         <template v-for="(value, annotation, index) in alert.annotations" class="dl-horizontal">
-            <dt>{{annotation}}</dt>
+            <dt>[[annotation]]</dt>
             <dd :inner-html.prop="value|urlize"></dd>
         </template>
     </dl>
 </td>
-{% endverbatim %}
 <td>
     <a @click.prevent="silenceAlert(alert)" class="btn btn-warning btn-xs">{% trans "Silence" %}</a>
 </td>

--- a/promgen/templates/promgen/global_messages.html
+++ b/promgen/templates/promgen/global_messages.html
@@ -7,13 +7,10 @@
 </div>
 {% endfor %}
 
-
-{% verbatim %}
 <div :class="m.class" role="alert" v-cloak v-for="m in globalMessages">
     <button type="button" class="close" data-dismiss="alert">
         <span aria-hidden="true">&times;</span>
     </button>
-    <strong v-if="m.label" v-text="m.label" ></strong>
-    {{ m.message }}
+    <strong v-if="m.label" v-text="m.label"></strong>
+    [[ m.message ]]
 </div>
-{% endverbatim %}

--- a/promgen/templates/promgen/silence_form.html
+++ b/promgen/templates/promgen/silence_form.html
@@ -13,9 +13,7 @@
       <ul class="list-inline">
         <li v-for="(value, label) in newSilence.labels">
           <a @click.prevent="silenceRemoveLabel(label)" class="label label-warning">
-            {% verbatim %}
-            {{label}}: {{ value }}
-            {% endverbatim %}
+            [[label]]: [[value]]
             <span class="glyphicon glyphicon-remove" aria-hidden="true"></span>
           </a>
         </li>

--- a/promgen/templates/promgen/silence_row.html
+++ b/promgen/templates/promgen/silence_row.html
@@ -1,18 +1,17 @@
 {% load i18n %}
-{% verbatim %}
-<td class="col-xs-1">{{silence.endsAt|time}}</td>
+<td class="col-xs-1">[[silence.endsAt|time]]</td>
 <td>
     <ul class="list-inline">
         <li v-for="match in silence.matchers">
             <a @click.prevent="silenceAppendLabel" class="label label-warning" :data-label="match.name" :data-value="match.value">
-                {{match.name}}:{{match.value}}
+                [[match.name]]:[[match.value]]
             </a>
         </li>
     </ul>
 </td>
 <td style="word-break: break-all;" :inner-html.prop="silence.comment|urlize"></td>
-<td>{{silence.createdBy}}</td>
-{% endverbatim %}
+<td>[[silence.createdBy]]</td>
+
 <td>
     <a @click.prevent="silenceExpire(silence.id)" class="btn btn-warning btn-xs">{% trans "Expire" %}</a>
 </td>

--- a/promgen/templates/promgen/silence_row.html
+++ b/promgen/templates/promgen/silence_row.html
@@ -4,7 +4,8 @@
 <td>
     <ul class="list-inline">
         <li v-for="match in silence.matchers">
-            <a @click.prevent="silenceAppendLabel" class="label label-warning" :data-label="match.name" :data-value="match.value">{{match.name}}:{{match.value}}</a>
+            <a @click.prevent="silenceAppendLabel" class="label label-warning" :data-label="match.name" :data-value="match.value">
+                {{match.name}}:{{match.value}}
             </a>
         </li>
     </ul>


### PR DESCRIPTION
Promgen often needs to deal with three different template languages, `Djagno`, `Vue`, and `Go`, and they all use the same `{{ }}` pattern for declaring templates. This shows up frequently on the Django side, where the `{% verbatim %}` needs to be used to ensure that **Vue** templates are not accidentally interpreted as **Django** templates (this happened a lot in initial development.

Recently, there have been cases when **Go** templates were rendered out to HTML from the rule editor, and then mistakenly rendered by **Vue**, causing the **Vue** renderer to throw an error and leave the page blank.

1. Fix one part of the **Django**, **Vue**, **Go** template mismatch, by changing the delimiters used so that they do not conflict. (This will also remove the requirement to use `{% verbatim %}` in several places)
2. There is still the possibility that a user could write a `[[ ]]` tag somewhere (intentionally for formatting reasons or by mistake) so need to go through and find places where this user input needs to be handled via a **Vue** `v-pre` tag. (Some of this may also be done in future pull requests as they're found)

Remaining tasks
- [ ] Finish some more auditing of `v-pre` tags
- [ ] Add developer note about changed **vue** delimiters