### PR TITLE
Fix typo in 'No results' message

### DIFF
--- a/promgen/views.py
+++ b/promgen/views.py
@@ -1318,7 +1318,7 @@ class RuleTest(LoginRequiredMixin, View):
                     context['status'] = 'warning'
         else:
             context['status'] = 'info'
-            context['errors']['no_results'] = 'No Results. May need to remove conditional check (> < ==) to verity'
+            context['errors']['no_results'] = 'No results. You may need to remove conditional checks (> < ==) to verify'
 
         # Place this at the bottom to have a query error show up as danger
         if result['status'] != 'success':


### PR DESCRIPTION
This PR fixes a typo in the 'No results' message (`verity` -> `verify`) and rewords the message a bit.