### PR TITLE
Split bootstrap checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,8 @@ test: ${APP_BIN}
 ## Django: Bootstrap install
 bootstrap: ${APP_BIN}
 	${APP_BIN} bootstrap
+	${APP_BIN} migrate
+	${APP_BIN} check
 
 .PHONY: check
 ## Django: Run Django checks

--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ docker run --rm -it -v ~/.config/promgen:/etc/promgen/ line/promgen bootstrap
 # Apply database updates
 docker run --rm -v ~/.config/promgen:/etc/promgen/ line/promgen migrate
 
+# You can then check your configuration to ensure everything correct
+docker run --rm -v ~/.config/promgen:/etc/promgen/ line/promgen check
+
 # Create initial login user. This is the same as the default django-admin command
 # https://docs.djangoproject.com/en/1.10/ref/django-admin/#django-admin-createsuperuser
 docker run --rm -it -v ~/.config/promgen:/etc/promgen/ line/promgen createsuperuser

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -36,7 +36,7 @@ web)
   shift
   set -- gunicorn "promgen.wsgi:application" "$@"
   ;;
-bootstrap|createsuperuser|migrate|shell|test|import|queuecheck|rbimport|register-server|register-exporter|rules|targets|urls)
+*)
   # Shortcuts for some commonly used django commands
   set -- promgen "$@"
   ;;

--- a/promgen/management/commands/bootstrap.py
+++ b/promgen/management/commands/bootstrap.py
@@ -5,10 +5,9 @@ import os
 import shutil
 
 from django.conf import settings
-from django.core.checks import registry
 from django.core.management.base import BaseCommand
 
-from promgen import PROMGEN_CONFIG_DIR, PROMGEN_CONFIG_FILE, checks
+from promgen import PROMGEN_CONFIG_DIR, PROMGEN_CONFIG_FILE
 
 PROMGEN_CONFIG_DEFAULT = (
     settings.BASE_DIR / "promgen" / "tests" / "examples" / "promgen.yml"
@@ -70,11 +69,3 @@ class Command(BaseCommand):
         self.setting("DATABASE_URL")
         self.setting("CELERY_BROKER_URL")
         self.stdout.write("")
-
-        self.write("Running django system checks", color=self.style.MIGRATE_HEADING)
-        # Since we want to run a few check commands that specifically require database access
-        # we will manually register them here (instead of automatically) so that they do not
-        # affect other commands that automatically run checks, or the management command checks
-        registry.register(checks.sites, "promgen")
-        registry.register(checks.shards, "promgen")
-        self.check(display_num_errors=True, tags=registry.registry.tags_available())


### PR DESCRIPTION
The bootstrap command has an issue where it is difficult to both configure the settings and test at the same time, because there is no easy way to also reload the django settings. This means we need to separate the commands. We also want to run some tests that require the database, but we can't have them enabled by default or other commands like migrate will be stuck in a chicken/egg problem. To get around this we create a decorator to check for database access for our checks that require it.

This is a continuation of documentation fixes for #299 and should handle the issue in #302 