### PR TITLE
Move checks that require database, to post_migrate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,11 @@ ${APP_BIN}: ${PIP_BIN}
 build:
 	docker-compose build base
 
+.PHONY: demo
+## Docker: Run a demo via docker-compose
+demo:
+	docker-compose up
+
 #### Django Commands
 
 .PHONY: test

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,8 @@ services:
     environment:
       CELERY_BROKER_URL: redis://redis:6379/0
       DATABASE_URL: mysql://promgen:promgen@mysql:3306/promgen
-      SECRET_KEY: asdf
+      SECRET_KEY: docker-compose-demo
+
 
   web:
     extends: base
@@ -20,8 +21,6 @@ services:
     links:
       - mysql
       - redis
-    environment:
-      DEBUG: 1
 
   worker:
     extends: base

--- a/promgen/checks.py
+++ b/promgen/checks.py
@@ -4,62 +4,7 @@ import pathlib
 from django.conf import settings
 from django.core import checks
 
-from promgen import models, util
-from django.db.transaction import get_autocommit
-
-# For a few of our checks, we want to be able to check the
-# database for values that exist or not. The easiest? way
-# to do this, seems to be to wrap our check with a check
-# to the database to see if it is connected
-def db_check(*tags):
-    def outer(func):
-        def inner(**kwargs):
-            try:
-                get_autocommit()
-            except:
-                yield checks.Warning(
-                    "Database not reachable",
-                    hint="Try running bootstrap again",
-                    id="promgen.W000",
-                )
-            else:
-                yield from func(**kwargs)
-
-        return checks.register(check=inner, tags=tags)
-
-    return outer
-
-
-@db_check("promgen")
-def sites(app_configs, **kwargs):
-    if models.Site.objects.count() == 0:
-        yield checks.Warning(
-            "Site not configured",
-            hint="Missing django site configuration",
-            id="promgen.W006",
-        )
-
-    for site in models.Site.objects.filter(
-        pk=settings.SITE_ID, domain__in=["example.com"]
-    ):
-        yield checks.Warning(
-            "Promgen is configured to example domain",
-            obj=site,
-            hint="Please update from admin page /admin/",
-            id="promgen.W007",
-        )
-
-
-@db_check("promgen")
-def shards(**kwargs):
-    if models.Shard.objects.filter(enabled=True).count() == 0:
-        yield checks.Warning(
-            "Missing shards", hint="Ensure some shards are enabled", id="promgen.W004"
-        )
-    if models.Shard.objects.filter(proxy=True).count() == 0:
-        yield checks.Warning(
-            "No proxy shards", hint="Ensure some shards are enabled", id="promgen.W004"
-        )
+from promgen import util
 
 
 @checks.register("settings")

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,7 @@ ignore = E501
 exclude = migrations
 
 [isort]
-not_skip = __init__.py
+float_to_top=true
 forced_separate=django,promgen
 known_django=django
 known_first_party=promgen


### PR DESCRIPTION
It's too fragile to run any kind of check that requires database, using the default [django.core.checks](https://docs.djangoproject.com/en/3.1/topics/checks#s-system-check-framework) framework.

[post_migrate](https://docs.djangoproject.com/en/3.1/ref/signals#s-post-migrate) does not have as pretty error messages, but we can be sure the rest of the database settings are correct.

Move the checks that require database to post_migrate, and we'll make the visible output better later.

Closes #302 #305 