### PR TITLE
Move our "Commit" button to Admin actions

### DIFF
--- a/promgen/actions.py
+++ b/promgen/actions.py
@@ -1,0 +1,71 @@
+from django.contrib import messages
+
+from promgen import tasks
+
+
+# Borrowed from Django 3.2a
+def action(function=None, *, permissions=None, description=None):
+    def decorator(func):
+        if permissions is not None:
+            func.allowed_permissions = permissions
+        if description is not None:
+            func.short_description = description
+        return func
+
+    if function is None:
+        return decorator
+    else:
+        return decorator(function)
+
+
+@action(description="Clear Tombstones")
+def prometheus_tombstones(modeladmin, request, queryset):
+    for server in queryset:
+        tasks.clear_tombstones.apply_async(queue=server.host)
+        messages.info(request, "Clear Tombstones on " + server.host)
+
+
+@action(description="Reload Configuration")
+def prometheus_reload(modeladmin, request, queryset):
+    for server in queryset:
+        tasks.reload_prometheus.apply_async(queue=server.host)
+        messages.info(request, "Reloading configuration on " + server.host)
+
+
+@action(description="Deploy Prometheus Targets")
+def prometheus_targets(modeladmin, request, queryset):
+    for server in queryset:
+        tasks.write_config.apply_async(queue=server.host)
+        messages.info(request, "Deploying targets to " + server.host)
+
+
+@action(description="Deploy Prometheus Rules")
+def prometheus_rules(modeladmin, request, queryset):
+    for server in queryset:
+        tasks.write_rules.apply_async(queue=server.host)
+        messages.info(request, "Deploying rules to " + server.host)
+
+
+@action(description="Deploy Prometheus Urls")
+def prometheus_urls(modeladmin, request, queryset):
+    for server in queryset:
+        tasks.write_urls.apply_async(queue=server.host)
+        messages.info(request, "Deploying urls to " + server.host)
+
+
+@action(description="Deploy Datasource Targets")
+def shard_targets(modeladmin, request, queryset):
+    for shard in queryset:
+        prometheus_targets(modeladmin, request, shard.prometheus_set.all())
+
+
+@action(description="Deploy Datasource Rules")
+def shard_rules(modeladmin, request, queryset):
+    for shard in queryset:
+        prometheus_rules(modeladmin, request, shard.prometheus_set.all())
+
+
+@action(description="Deploy Datasource Urls")
+def shard_urls(modeladmin, request, queryset):
+    for shard in queryset:
+        prometheus_urls(modeladmin, request, shard.prometheus_set.all())

--- a/promgen/admin.py
+++ b/promgen/admin.py
@@ -5,11 +5,13 @@ import json
 from django import forms
 from django.contrib import admin
 from django.utils.html import format_html
-from promgen import models, plugins
+
+from promgen import actions, models, plugins
 
 
 class PrometheusInline(admin.TabularInline):
     model = models.Prometheus
+
 
 class FilterInline(admin.TabularInline):
     model = models.Filter
@@ -22,9 +24,14 @@ class HostAdmin(admin.ModelAdmin):
 
 @admin.register(models.Shard)
 class ShardAdmin(admin.ModelAdmin):
-    list_display = ('name', 'url', 'proxy', 'enabled')
-    list_filter = ('proxy', 'enabled')
+    list_display = ("name", "url", "proxy", "enabled")
+    list_filter = ("proxy", "enabled")
     inlines = [PrometheusInline]
+    actions = [
+        actions.shard_targets,
+        actions.shard_rules,
+        actions.shard_urls,
+    ]
 
 
 @admin.register(models.Service)
@@ -119,8 +126,15 @@ class RuleAdmin(admin.ModelAdmin):
 
 @admin.register(models.Prometheus)
 class PrometheusAdmin(admin.ModelAdmin):
-    list_display = ('shard', 'host', 'port')
-    list_filter = ('shard',)
+    list_display = ("shard", "host", "port")
+    list_filter = ("shard",)
+    actions = [
+        actions.prometheus_targets,
+        actions.prometheus_rules,
+        actions.prometheus_urls,
+        actions.prometheus_reload,
+        actions.prometheus_tombstones,
+    ]
 
 
 @admin.register(models.Alert)

--- a/promgen/templates/promgen/navbar.html
+++ b/promgen/templates/promgen/navbar.html
@@ -55,10 +55,6 @@
                 </div>
                 <button type="submit" class="btn btn-default">Search</button>
             </form>
-            <form style="display:inline;" action="{% url 'commit' %}" method="POST">
-                <input name="next" type="hidden" value="{{ request.get_full_path }}" />
-                <button type="submit" class="btn btn-primary">Commit</button>
-            </form>
             <a @click.prevent="toggleTarget('globalAlerts')" id="toggleAlerts" class="btn btn-danger navbar-btn" role="button">Alerts
                 <span v-text="filterActiveAlerts.length" class="badge"></span>
             </a>

--- a/promgen/urls.py
+++ b/promgen/urls.py
@@ -98,7 +98,6 @@ urlpatterns = [
     path('search', views.Search.as_view(), name='search'),
 
     path('metrics', csrf_exempt(views.Metrics.as_view()), name='metrics'),
-    path('commit', csrf_exempt(views.Commit.as_view()), name='commit'),
 
     path('alert', views.AlertList.as_view(), name='alert-list'),
     path('alert/<int:pk>', views.AlertDetail.as_view(), name='alert-detail'),

--- a/promgen/views.py
+++ b/promgen/views.py
@@ -985,12 +985,6 @@ class ApiQueue(View):
         return HttpResponse('OK', status=202)
 
 
-class Commit(LoginRequiredMixin, View):
-    def post(self, request):
-        signals.trigger_write_config.send(request)
-        return HttpResponseRedirect(request.POST.get('next', '/'))
-
-
 class _ExportRules(View):
     def format(self, rules=None, name='promgen'):
         content = prometheus.render_rules(rules)


### PR DESCRIPTION
Previously our "Commit" button was somewhat awkwardly placed, and only handled deploying targets. Move to an admin action and support deploying rules and urls as well.