### PR TITLE
[IMPROVEMENT] Change history dropdown

### DIFF
--- a/promgen/templates/promgen/alert_list.html
+++ b/promgen/templates/promgen/alert_list.html
@@ -12,7 +12,7 @@
     </div>
 </form>
 
-<table class="table">
+<table class="table table-sm">
     <tr>
         <th>Created</th>
         <th>Alertname</th>

--- a/promgen/templates/promgen/audit_list.html
+++ b/promgen/templates/promgen/audit_list.html
@@ -13,7 +13,7 @@
 <li>
   <a
     class="btn btn-danger btn-xs"
-    href="{% url 'audit-list' %}?{% qsfilter request k None %}"
+    href="{% url 'audit-list' %}?{% qs_replace k None %}"
     >{{k}} &times;</a>
 {% endfor %}
 </ul>
@@ -33,7 +33,7 @@
       <tr class="{{ entry.highlight }}">
         <td>{{ entry.created|timezone:TIMEZONE }}</td>
         <td>
-          <a href="{% url 'audit-list' %}?{% qsfilter request 'user' entry.user.id %}">{{ entry.user }}</a>
+          <a href="{% url 'audit-list' %}?{% qs_replace 'user' entry.user.id %}">{{ entry.user }}</a>
         </td>
         <td>
           {{ entry.body }}

--- a/promgen/templates/promgen/home.html
+++ b/promgen/templates/promgen/home.html
@@ -3,7 +3,7 @@
 {% block content %}
 
 {% for service in service_list %}
-<h2><a href="{% url 'service-detail' service.id %}">{{ service.name }}</a></h2>
+{% include "promgen/service_header.html" %}
 {% include "promgen/service_block.html" %}
 {% empty %}
 <h3>No Subscriptions Found</h3>

--- a/promgen/templates/promgen/project_detail_configuration.html
+++ b/promgen/templates/promgen/project_detail_configuration.html
@@ -1,4 +1,5 @@
 {% load i18n %}
+{% load promgen %}
 
 <div class="panel panel-primary">
   <div class="panel-heading">Configuration</div>
@@ -20,7 +21,16 @@
       <button class="btn btn-primary btn-sm">{% trans "Subscribe to Notifications" %}</button>
     </form>
 
-    <a href="{% url 'audit-list'  %}?project={{project.id}}" class="btn btn-info btn-sm">{% trans "Edit History" %}</a>
+    <div class="btn-group btn-group-sm" role="group" aria-label="...">
+      <button type="button" class="btn btn-info dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+        {% trans "Change History" %} <span class="caret"></span>
+      </button>
+      <ul class="dropdown-menu">
+        <li role="presentation"><a href="{% urlqs 'audit-list' project=project.id  %}">{% trans "Edit History" %}</a></li>
+        <li role="presentation"><a href="{% urlqs 'alert-list' project=project.name %}">{% trans "Alert History" %}</a></li>
+      </ul>
+    </div>
+
     <a href="{% url 'project-update' project.id %}" class="btn btn-warning btn-sm">{% trans "Update Project" %}</a>
     <a @click.prevent="silenceSetLabels" class="btn btn-warning btn-sm" data-project="{{project.name}}" data-service="{{project.service.name}}">{% trans "Silence" %}</a>
 

--- a/promgen/templates/promgen/rule_detail.html
+++ b/promgen/templates/promgen/rule_detail.html
@@ -32,6 +32,7 @@ Promgen / Rule / {{ rule.name }}
     </div>
     <div class="panel-footer">
         <a href="{% url 'rule-edit' rule.pk %}" class="btn btn-warning btn-sm">{% trans "Edit Rule" %}</a>
+        <a href="{% urlqs 'alert-list' alertname=rule.name %}" class="btn btn-info btn-sm">{% trans "Alert History" %}</a>
     </div>
 </div>
 

--- a/promgen/templates/promgen/rule_update.html
+++ b/promgen/templates/promgen/rule_update.html
@@ -93,7 +93,8 @@ Promgen / Rule / {{ rule.name }}
   <div class="panel panel-primary">
     <div class="panel-body">
       <button class="btn btn-primary">Save Rule</button>
-      <a href="{% url 'audit-list'  %}?rule={{rule.id}}" class="btn btn-info">{% trans "Edit History" %}</a>
+      <a href="{% urlqs 'audit-list' rule=rule.id %}" class="btn btn-info">{% trans "Edit History" %}</a>
+      <a href="{% urlqs 'alert-list' alertname=rule.name %}" class="btn btn-info">{% trans "Alert History" %}</a>
     </div>
   </div>
 </form>

--- a/promgen/templates/promgen/service_block.html
+++ b/promgen/templates/promgen/service_block.html
@@ -1,4 +1,5 @@
 {% load i18n %}
+{% load promgen %}
 <div class="well">
   <div data-service="{{service.name}}" class="panel panel-danger" v-cloak v-show="alertLabelsService.has('{{service.name}}')">
     <div class="panel-heading">
@@ -49,7 +50,15 @@
         <button class="btn btn-primary btn-sm">{% trans "Subscribe to Notifications" %}</button>
       </form>
 
-      <a href="{% url 'audit-list'  %}?service={{service.id}}" class="btn btn-info btn-sm">{% trans "Service History" %}</a>
+      <div class="btn-group btn-group-sm" role="group" aria-label="...">
+        <button type="button" class="btn btn-info dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+          {% trans "Change History" %} <span class="caret"></span>
+        </button>
+        <ul class="dropdown-menu">
+          <li role="presentation"><a href="{% urlqs 'audit-list' service=service.id %}">{% trans "Edit History" %}</a></li>
+          <li role="presentation"><a href="{% urlqs 'alert-list' service=service.name %}">{% trans "Alert History" %}</a></li>
+        </ul>
+      </div>
 
       <a href="{% url 'service-update' service.id %}" class="btn btn-warning btn-sm">{% trans "Edit Service" %}</a>
       <a @click.prevent="silenceSetLabels" data-service="{{service.name}}" class="btn btn-warning btn-sm">{% trans "Silence" %}</a>

--- a/promgen/templates/promgen/service_header.html
+++ b/promgen/templates/promgen/service_header.html
@@ -1,0 +1,8 @@
+{% load i18n %}
+
+<h2>
+    <a href="{% url 'service-detail' service.id %}">{{ service.name }}</a>
+    {% if service.owner %}
+    <small class="pull-right">{% trans 'Contact' %}: {{service.owner.username}}</small>
+    {% endif %}
+</h2>

--- a/promgen/templates/promgen/service_list.html
+++ b/promgen/templates/promgen/service_list.html
@@ -14,13 +14,7 @@
 {% include "promgen/pagination.html" %}
 
 {% for service in service_list %}
-<h2>
-  <a href="{% url 'service-detail' service.id %}">{{ service.name }}</a>
-  {% if service.owner %}
-  <small class="pull-right">{% trans 'Contact' %}: {{service.owner.username}}</small>
-  {% endif %}
-</h2>
-
+{% include "promgen/service_header.html" %}
 {% include "promgen/service_block.html" %}
 {% endfor %}
 

--- a/promgen/templatetags/promgen.py
+++ b/promgen/templatetags/promgen.py
@@ -75,29 +75,6 @@ def rulemacro(rule, clause=None):
 
 
 @register.simple_tag
-def qsfilter(request, k, v):
-    '''
-    Helper to rewrite query string for URLs
-
-    {% qsfilter request 'foo' 'baz' %}
-    When passed the request object, it will take a querystring like
-    ?foo=bar&donottouch=1
-    and change it to
-    ?foo=baz&donottouch=1
-
-    Useful when working with filtering on a page that also uses pagination to
-    avoid losing other query strings
-    {% qsfilter request 'page' page_obj.previous_page_number %}
-    '''
-    dict_ = request.GET.copy()
-    if v:
-        dict_[k] = v
-    else:
-        dict_.pop(k, None)
-    return dict_.urlencode()
-
-
-@register.simple_tag
 def diff_json(a, b):
     if isinstance(a, str):
         a = json.loads(a)

--- a/promgen/templatetags/promgen.py
+++ b/promgen/templatetags/promgen.py
@@ -5,17 +5,18 @@ import collections
 import difflib
 import json
 from datetime import datetime
+from urllib.parse import urlencode
 
 import yaml
 from pytz import timezone
-
-from promgen import util
 
 from django import template
 from django.urls import reverse
 from django.utils.html import format_html
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext as _
+
+from promgen import util
 
 register = template.Library()
 
@@ -199,3 +200,17 @@ def qs_replace(context, k, v):
     else:
         dict_.pop(k, None)
     return dict_.urlencode()
+
+
+@register.simple_tag
+def urlqs(view, **kwargs):
+    """
+    Query string aware version of url template
+
+    Instead of using {% url 'view' %}
+    Use {% urlqs 'view' param=value %}
+
+    This is useful for linking to pages that use filters.
+    This only works for views that do not need additional parameters
+    """
+    return reverse(view) + "?" + urlencode(kwargs)


### PR DESCRIPTION
<img width="669" alt="change-dropdown" src="https://user-images.githubusercontent.com/89725/130172128-1c3814ac-4642-4e03-8b0d-0aa31d20710b.png">

Update History button for Edits and Alerts

- Add templatetag `urlqs` for making it easier to link to filtered pages
- Put Edit History and Alert History under combined Change History dropdown