### PR TITLE
[IMPROVEMENT] Improve list rendering in Vue

### DIFF
--- a/promgen/static/js/promgen.js
+++ b/promgen/static/js/promgen.js
@@ -1,7 +1,27 @@
 /*
-# Copyright (c) 2017 LINE Corporation
-# These sources are released under the terms of the MIT license: see LICENSE
-*/
+ * Copyright (c) 2021 LINE Corporation
+ * These sources are released under the terms of the MIT license: see LICENSE
+ */
+
+function groupByLabel(items, label) {
+  const groups = new Map();
+
+  for (const item of items) {
+    const key = item.labels[label];
+    if (!key) {
+      continue;
+    }
+
+    const group = groups.get(key);
+    if (group) {
+      group.push(item);
+    } else {
+      groups.set(key, [item]);
+    }
+  }
+
+  return groups;
+}
 
 function update_page(data) {
   for (var key in data) {

--- a/promgen/templates/promgen/alert_row.html
+++ b/promgen/templates/promgen/alert_row.html
@@ -8,12 +8,12 @@
         <dt>Labels</dt>
         <dd>
             <ul class="list-inline">
-                <li v-for="(value, label, index) in alert.labels">
+                <li v-for="(value, label) in alert.labels">
                     <a @click.prevent="silenceAppendLabel" class="label label-danger" :data-label="label" :data-value="value">[[label]]:[[value]]</a>
                 </li>
             </ul>
         </dd>
-        <template v-for="(value, annotation, index) in alert.annotations" class="dl-horizontal">
+        <template v-for="(value, annotation) in alert.annotations" class="dl-horizontal">
             <dt>[[annotation]]</dt>
             <dd :inner-html.prop="value|urlize"></dd>
         </template>

--- a/promgen/templates/promgen/global_alerts.html
+++ b/promgen/templates/promgen/global_alerts.html
@@ -5,7 +5,7 @@
     </div>
 
     <table class="table table-bordered table-condensed">
-        <tr v-for="(alert, index) in filterActiveAlerts">
+        <tr v-for="alert in activeAlerts">
             {% include 'promgen/alert_row.html' %}
         </tr>
     </table>

--- a/promgen/templates/promgen/global_silences.html
+++ b/promgen/templates/promgen/global_silences.html
@@ -12,7 +12,7 @@
             <th>CreatedBy</th>
             <th>&nbsp;</th>
         </tr>
-        <tr v-for="(silence, index) in filterActiveSilences">
+        <tr v-for="silence in activeSilences">
             {% include 'promgen/silence_row.html' %}
         </tr>
     </table>

--- a/promgen/templates/promgen/navbar.html
+++ b/promgen/templates/promgen/navbar.html
@@ -57,11 +57,11 @@
             </form>
             <a @click="toggleComponent('global-alerts')" class="btn btn-danger navbar-btn" role="button">
                 Alerts
-                <span v-text="filterActiveAlerts.length" class="badge"></span>
+                <span v-text="activeAlerts.length" class="badge"></span>
             </a>
             <a @click="toggleComponent('global-silences')" class="btn btn-warning navbar-btn" role="button">
                 Silences
-                <span v-text="filterActiveSilences.length" class="badge"></span>
+                <span v-text="activeSilences.length" class="badge"></span>
             </a>
 
             <ul class="nav navbar-nav navbar-right">

--- a/promgen/templates/promgen/project_detail.html
+++ b/promgen/templates/promgen/project_detail.html
@@ -29,23 +29,23 @@ Promgen / Project / {{ project.name }}
 
 {% include "promgen/project_detail_configuration.html" %}
 
-<div class="panel panel-danger" v-cloak v-if="alertLabelsProject.has('{{project.name}}')">
+<div class="panel panel-danger" v-cloak v-if="activeProjectAlerts.has('{{project.name}}')">
   <div class="panel-heading">
     <a @click="toggleCollapse('alerts-project-{{project.name|slugify}}')" class="btn btn-danger btn-sm" role="button">Alerts</a>
   </div>
   <table id="alerts-project-{{project.name|slugify}}" class="table table-bordered table-condensed">
-    <tr v-for="(alert, index) in globalAlerts" v-if="alert.labels.project == '{{project.name}}'">
+    <tr v-for="alert in activeProjectAlerts.get('{{project.name}}')">
       {% include 'promgen/alert_row.html' %}
     </tr>
   </table>
 </div>
 
-<div id="silence-project-{{ project.name|slugify }}" class="panel panel-warning" v-cloak v-if="silenceLabelsProject.has('{{project.name}}')">
+<div id="silence-project-{{ project.name|slugify }}" class="panel panel-warning" v-cloak v-if="activeProjectSilences.has('{{project.name}}')">
   <div class="panel-heading">
     <a @click="toggleCollapse('silences-project-{{project.name|slugify}}')" class="btn btn-warning btn-sm" role="button">Silences</a>
   </div>
   <table id="silences-project-{{project.name|slugify}}" class="table table-bordered table-condensed">
-    <tr v-for="(silence, index) in filterActiveSilences" v-if="silence.labels.project == '{{project.name}}'">
+    <tr v-for="silence in activeProjectSilences.get('{{project.name}}')">
       {% include 'promgen/silence_row.html' %}
     </tr>
   </table>

--- a/promgen/templates/promgen/rule_detail.html
+++ b/promgen/templates/promgen/rule_detail.html
@@ -14,12 +14,12 @@ Promgen / Rule / {{ rule.name }}
 
 {% breadcrumb rule  %}
 
-<div class="panel panel-danger" v-cloak v-if="alertLabelsRule.has('{{rule.name}}')" data-service="{{rule.name}}">
+<div class="panel panel-danger" v-cloak v-if="activeRuleAlerts.has('{{rule.name}}')" data-service="{{rule.name}}">
     <div class="panel-heading">
         <a @click="toggleComponent('alerts-service-{{rule.name|slugify}}')" class="btn btn-danger btn-sm" role="button">Alerts</a>
     </div>
     <table v-if="components['alerts-service-{{rule.name|slugify}}']" class="table table-bordered table-condensed">
-        <tr v-for="(alert, index) in globalAlerts" v-if="alert.labels.alertname == '{{rule.name}}'">
+        <tr v-for="alert in activeRuleAlerts.get('{{rule.name}}')">
             {% include 'promgen/alert_row.html' %}
         </tr>
     </table>

--- a/promgen/templates/promgen/rule_update.html
+++ b/promgen/templates/promgen/rule_update.html
@@ -14,12 +14,12 @@ Promgen / Rule / {{ rule.name }}
 
 {% breadcrumb rule 'Edit Rule' %}
 
-<div data-service="{{rule.name}}" class="panel panel-danger" v-cloak v-if="alertLabelsRule.has('{{rule.name}}')">
+<div data-service="{{rule.name}}" class="panel panel-danger" v-cloak v-if="activeRuleAlerts.has('{{rule.name}}')">
   <div class="panel-heading">
     <a @click="toggleComponent('alerts-service-{{rule.name|slugify}}')" class="btn btn-danger btn-sm" role="button">Alerts</a>
   </div>
   <table v-if="components['alerts-service-{{rule.name|slugify}}']" class="table table-bordered table-condensed">
-    <tr v-for="(alert, index) in globalAlerts" v-if="alert.labels.alertname == '{{rule.name}}'">
+    <tr v-for="alert in activeRuleAlerts.get('{{rule.name}}')">
       {% include 'promgen/alert_row.html' %}
     </tr>
   </table>

--- a/promgen/templates/promgen/service_block.html
+++ b/promgen/templates/promgen/service_block.html
@@ -1,23 +1,23 @@
 {% load i18n %}
 {% load promgen %}
 <div class="well">
-  <div data-service="{{service.name}}" class="panel panel-danger" v-cloak v-if="alertLabelsService.has('{{service.name}}')">
+  <div data-service="{{service.name}}" class="panel panel-danger" v-cloak v-if="activeServiceAlerts.has('{{service.name}}')">
     <div class="panel-heading">
       <a @click="toggleComponent('alerts-service-{{service.name|slugify}}')" class="btn btn-danger btn-sm" role="button">Alerts</a>
     </div>
     <table v-if="components['alerts-service-{{service.name|slugify}}']" class="table table-bordered table-condensed">
-      <tr v-for="(alert, index) in globalAlerts" v-if="alert.labels.service == '{{service.name}}'">
+      <tr v-for="alert in activeServiceAlerts.get('{{service.name}}')">
         {% include 'promgen/alert_row.html' %}
       </tr>
     </table>
   </div>
 
-  <div id="silence-service-{{ service.name|slugify }}" class="panel panel-warning" v-cloak v-if="silenceLabelsService.has('{{service.name}}')">
+  <div id="silence-service-{{ service.name|slugify }}" class="panel panel-warning" v-cloak v-if="activeServiceSilences.has('{{service.name}}')">
     <div class="panel-heading">
       <a @click="toggleComponent('silences-service-{{service.name|slugify}}')" class="btn btn-warning btn-sm" role="button">Silences</a>
     </div>
     <table v-if="components['silences-service-{{service.name|slugify}}']" class="table table-bordered table-condensed">
-      <tr v-for="(silence, index) in filterActiveSilences" v-if="silence.labels.service == '{{service.name}}'">
+      <tr v-for="silence in activeServiceSilences.get('{{service.name}}')">
         {% include 'promgen/silence_row.html' %}
       </tr>
     </table>


### PR DESCRIPTION
## Description
This PR refactors the way alert and silence lists are rendered, by removing `v-if` from `v-for` directives. This way we avoid any runtime errors and unnecessary iterations.

## Detailed changes
* Update `computed` field to return `Map` instead of `Set`
* Use these new maps in `v-for` to avoid the need for additional filters
* Remove unused `index` variable in iterations