### PR TITLE
[BUGFIX] Missing CSRF token on API page

### DIFF
--- a/promgen/templates/rest_framework/api.html
+++ b/promgen/templates/rest_framework/api.html
@@ -17,6 +17,13 @@ https://github.com/tomchristie/django-rest-framework/blob/master/rest_framework/
 {% endblock %}
 
 {% block script %}
+<script>
+    window.drf = {
+        csrfHeaderName: "{{ csrf_header_name|default:'X-CSRFToken' }}",
+        csrfToken: "{% if request %}{{ csrf_token }}{% endif %}"
+    };
+</script>
+
 <script src="{% static 'js/jquery.min.js' %}"></script>
 <script src="{% static 'js/jquery.selection.js' %}"></script>
 <script src="{% static 'js/bootstrap.min.js' %}"></script>
@@ -27,6 +34,7 @@ https://github.com/tomchristie/django-rest-framework/blob/master/rest_framework/
 <script src="{% static 'rest_framework/js/csrf.js' %}"></script>
 <script src="{% static 'rest_framework/js/prettify-min.js' %}"></script>
 <script src="{% static 'rest_framework/js/default.js' %}"></script>
+
 <script>
     $(document).ready(function () {
         $('form').ajaxForm();


### PR DESCRIPTION
## Description
This PR fixes a JavaScript error about a missing CSRF token on the API page.

## Detailed changes
* Update `api.html` based on [`base.html`](https://github.com/encode/django-rest-framework/blob/master/rest_framework/templates/rest_framework/base.html#L290-L295) in Django REST Framework, to include a CSRF token