### PR TITLE
[BUGFIX] envdir import fix

### DIFF
--- a/promgen/__init__.py
+++ b/promgen/__init__.py
@@ -17,6 +17,9 @@ PROMGEN_CONFIG_FILE = pathlib.Path(
     os.environ.get("PROMGEN_CONFIG", str(PROMGEN_CONFIG_DIR / "promgen.yml"))
 )
 
+# In the future we want to remove the dependency on envdir, but this will
+# require some cleanup and documentation changes, so for now we will just
+# ensure that it can't fail here if envdir is not already installed
 if PROMGEN_CONFIG_DIR.exists():
     try:
         import envdir

--- a/promgen/__init__.py
+++ b/promgen/__init__.py
@@ -18,9 +18,12 @@ PROMGEN_CONFIG_FILE = pathlib.Path(
 )
 
 if PROMGEN_CONFIG_DIR.exists():
-    import envdir
-
-    envdir.open(PROMGEN_CONFIG_DIR)
+    try:
+        import envdir
+    except ImportError:
+        pass
+    else:
+        envdir.open(PROMGEN_CONFIG_DIR)
 
 
 if "SECRET_KEY" not in os.environ:


### PR DESCRIPTION
When initially installing Promgen, envdir may not already be installed, but this path gets resolved trying to read the version from `promgen.version`.  