### PR TITLE
[BUGFIX] Hostname validator based off URLValidator

### DIFF
--- a/promgen/tests/test_host_add.py
+++ b/promgen/tests/test_host_add.py
@@ -8,24 +8,27 @@ from promgen import forms, models
 from promgen.tests import PromgenTest
 
 
-class RouteTests(PromgenTest):
+class HostTests(PromgenTest):
     longMessage = True
+    fixtures = ["testcases.yaml"]
 
     def setUp(self):
         self.add_force_login(id=999, username="Foo")
 
     def test_newline(self):
-        farm = models.Farm.objects.create(name='Foo')
-        self.client.post(reverse('hosts-add', args=[farm.pk]), {
-            'hosts': "\naaa\nbbb\nccc \n"
-        }, follow=False)
+        self.client.post(
+            reverse("hosts-add", args=[1]),
+            {"hosts": "\naaa.example.com\nbbb.example.com\nccc.example.com \n"},
+            follow=False,
+        )
         self.assertCount(models.Host, 3, "Expected 3 hosts")
 
     def test_comma(self):
-        farm = models.Farm.objects.create(name='Foo')
-        self.client.post(reverse('hosts-add', args=[farm.pk]), {
-            'hosts': ",,aaa, bbb,ccc,"
-        }, follow=False)
+        self.client.post(
+            reverse("hosts-add", args=[1]),
+            {"hosts": ",,aaa.example.com, bbb.example.com,ccc.example.com,"},
+            follow=False,
+        )
         self.assertCount(models.Host, 3, "Expected 3 hosts")
 
     def test_invalid(self):

--- a/promgen/validators.py
+++ b/promgen/validators.py
@@ -4,7 +4,7 @@
 from dateutil import parser
 
 from django.core.exceptions import ValidationError
-from django.core.validators import RegexValidator
+from django.core.validators import RegexValidator, URLValidator
 
 # See definition of duration field
 # https://prometheus.io/docs/prometheus/latest/configuration/configuration/#configuration-file
@@ -29,8 +29,16 @@ labelvalue = RegexValidator(
     r"^[\w][- \w]+\Z", "Unicode letters, numbers, underscores, or hyphens or spaces"
 )
 
-hostname = RegexValidator(r"^\w+$", "Invalid hostname %(value)s")
-
+hostname = RegexValidator(
+    regex=r"^("
+    + URLValidator.ipv4_re
+    + "|"
+    + URLValidator.ipv6_re
+    + "|"
+    + URLValidator.host_re
+    + ")$",
+    message="Invalid hostname %(value)s",
+)
 
 def datetime(value):
     try:


### PR DESCRIPTION
Our previous fix (in #380) was too naive, and forgets `.` and other characters that can be in a hostname. May be better to base it on the existing URLValidator