### PR TITLE
[BUGFIX] Fix missing closing div tag which triggered VueJS error

### DIFF
--- a/promgen/templates/promgen/notifier_form.html
+++ b/promgen/templates/promgen/notifier_form.html
@@ -38,5 +38,5 @@
     </div>
     {% endfor %}
   </div>
-
+</div>
 {% endblock %}


### PR DESCRIPTION
While the missing div tag is likely from a change several years ago, the recent changes our Vuejs code have caused parts of the code to be (correctly) more strict, causing this error to become visible on the notifier edit page.

While this error was exposed by #377 the mismatched tag was likely added in https://github.com/line/promgen/commit/4e98e9be5ced058567ad9dab4f4f2be5adfedf7a#diff-c741593aed98e419f1a6817df3e761a2eaf49e9421945b42cd0632d2c34e8ce9
when we moved some of the templates around

cc @KarboniteKream