### PR TITLE
[BUGFIX] Update validator to allow hostname only entries

### DIFF
--- a/promgen/tests/test_host_add.py
+++ b/promgen/tests/test_host_add.py
@@ -4,7 +4,7 @@
 
 from django.urls import reverse
 
-from promgen import forms, models
+from promgen import models, validators
 from promgen.tests import PromgenTest
 
 
@@ -12,6 +12,9 @@ class HostTests(PromgenTest):
     def setUp(self):
         self.force_login(username="demo")
 
+    # For our first two tests, we just want to make sure that both newline
+    # separated and comma separated work, but are not necessarily testing
+    # valid/invalid hostnames
     def test_newline(self):
         self.client.post(
             reverse("hosts-add", args=[1]),
@@ -28,14 +31,25 @@ class HostTests(PromgenTest):
         )
         self.assertCount(models.Host, 3, "Expected 3 hosts")
 
-    def test_invalid(self):
-        form = forms.HostForm(
-            {
-                "hosts": """
-            foo/bar/baz
-            not-a-valid:host
-            """
-            }
-        )
-        self.assertFalse(form.is_valid(), "Form uses invalid hosts")
-        self.assertEquals(form.errors, {"__all__": ["Invalid hostname foo/bar/baz"]})
+    # Within our new host code, the hosts are split (by newline or comma) and then
+    # individually tested. Here we will test our validator on specific entries that
+    # should pass or fail
+    def test_validators(self):
+        # Hostname only should be valid
+        validators.hostname("bare-hostname")
+        # FQDN should be valid
+        validators.hostname("fqdn.example.com")
+        # UPPERCASE and trailing dot should also be fine
+        validators.hostname("FQDN.with.trailing.dot.example.com.")
+        # Hostname cannot contain underscore
+        with self.assertRaises(validators.ValidationError):
+            validators.hostname("underscore_in_hostname")
+        # Hostname should not include port
+        with self.assertRaises(validators.ValidationError):
+            validators.hostname("invalid:host")
+        # Hostname should not be a url (no scheme)
+        with self.assertRaises(validators.ValidationError):
+            validators.hostname("http://example.com")
+        # Hostnames should not contain a path component
+        with self.assertRaises(validators.ValidationError):
+            validators.hostname("example.com/path")

--- a/promgen/validators.py
+++ b/promgen/validators.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017 LINE Corporation
 # These sources are released under the terms of the MIT license: see LICENSE
 
+import re
+
 from dateutil import parser
 
 from django.core.exceptions import ValidationError
@@ -36,9 +38,13 @@ hostname = RegexValidator(
     + URLValidator.ipv6_re
     + "|"
     + URLValidator.host_re
+    + "|"
+    + URLValidator.hostname_re
     + ")$",
-    message="Invalid hostname %(value)s",
+    message="Invalid hostname: %(value)s",
+    flags=re.IGNORECASE,
 )
+
 
 def datetime(value):
     try:


### PR DESCRIPTION
One more attempt to fix the edge cases for validating hostnames. We want to allow bare hostnames and fqdn, but not allow any other special characters like an accidental port or path part

References #383 #380