### PR TITLE
[IMPROVEMENT] Support help_menu.inc.html override

### DIFF
--- a/promgen/context_processors.py
+++ b/promgen/context_processors.py
@@ -7,7 +7,6 @@ from promgen.version import __version__
 
 def settings_in_view(request):
     return {
-        "EXTERNAL_LINKS": util.setting("links", {}),
         "TIMEZONE": util.setting("timezone", "UTC"),
         "VERSION": __version__,
         "DEFAULT_EXPORTERS": models.DefaultExporter.objects.order_by("job", "-port"),

--- a/promgen/settings.py
+++ b/promgen/settings.py
@@ -56,18 +56,20 @@ ALLOWED_HOSTS = env.list("ALLOWED_HOSTS", default=["127.0.0.1", "localhost"])
 # Application definition
 
 INSTALLED_APPS = apps_from_setuptools + [
-    'django.contrib.admin',
-    'django.contrib.auth',
-    'django.contrib.contenttypes',
-    'django.contrib.sessions',
-    'django.contrib.messages',
-    'django.contrib.sites',
-    'django.contrib.staticfiles',
-    'social_django',
-    'promgen',
-    'rest_framework',
-    'rest_framework.authtoken',
-    'django_filters',
+    "promgen",
+    # Third Party
+    "django_filters",
+    "rest_framework.authtoken",
+    "rest_framework",
+    "social_django",
+    # Django
+    "django.contrib.admin",
+    "django.contrib.auth",
+    "django.contrib.contenttypes",
+    "django.contrib.sessions",
+    "django.contrib.messages",
+    "django.contrib.sites",
+    "django.contrib.staticfiles",
 ]
 
 # We explicitly include debug_toolbar and whitenoise here, but selectively

--- a/promgen/templates/promgen/help_menu.inc.html
+++ b/promgen/templates/promgen/help_menu.inc.html
@@ -1,0 +1,7 @@
+<li class="dropdown">
+    <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+    <ul class="dropdown-menu">
+        <li><a rel="noopener noreferrer" href="https://promgen.readthedocs.io/">Documentation</a></li>
+        <li><a rel="noopener noreferrer" href="https://github.com/line/promgen/releases">Changelog</a></li>
+    </ul>
+</li>

--- a/promgen/templates/promgen/navbar.html
+++ b/promgen/templates/promgen/navbar.html
@@ -37,17 +37,9 @@
                         <li><a href="{% url 'config-targets' %}">Export Targets</a></li>
                         <li><a href="{% url 'api:all-rules' %}">Export Rules</a></li>
                         <li><a href="{% url 'config-urls' %}">Export URL</a></li>
-
-                        {% if EXTERNAL_LINKS %}
-                        <li role="separator" class="divider"></li>
-                        {% for title, link in EXTERNAL_LINKS.items %}
-                        <li><a rel="noopener noreferrer" href="{{ link }}">{{ title }}</a></li>
-                        {% endfor %}
-
-                        {% endif %}
                     </ul>
                 </li>
-                <li><a href="https://promgen.readthedocs.io/">Help</a></li>
+                {% include 'promgen/help_menu.inc.html' %}
             </ul>
             <form class="navbar-form navbar-left" action="{% url 'search' %}">
                 <div class="form-group">
@@ -80,8 +72,9 @@
                 </li>
             </ul>
             {% else %}
-            <ul class="nav navbar-nav navbar-right">
+            <ul class="nav navbar-nav">
                 <li><a href="{% url 'login' %}">Login</a></li>
+                {% include 'promgen/help_menu.inc.html' %}
             </ul>
             {% endif %}
         </div><!-- /.navbar-collapse -->


### PR DESCRIPTION
Replace our EXTERNAL_LINKS settings with a template override to allow more flexibility in customizing the menu option and how things are displayed.