### PR TITLE
[BUGFIX] Fix for duplicate user subscribe

### DIFF
--- a/promgen/signals.py
+++ b/promgen/signals.py
@@ -299,6 +299,7 @@ def add_default_service_subscription(instance, created, **kwargs):
             obj=instance,
             sender="promgen.notification.user",
             value=instance.owner.username,
+            defaults={"owner": instance.owner},
         )
 
 
@@ -309,4 +310,5 @@ def add_default_project_subscription(instance, created, **kwargs):
             obj=instance,
             sender="promgen.notification.user",
             value=instance.owner.username,
+            defaults={"owner": instance.owner},
         )

--- a/promgen/views.py
+++ b/promgen/views.py
@@ -889,8 +889,12 @@ class ProjectNotifierRegister(LoginRequiredMixin, FormView, mixins.ProjectMixin)
     form_class = forms.SenderForm
 
     def form_valid(self, form):
-        project = get_object_or_404(models.Project, id=self.kwargs['pk'])
-        sender, created = models.Sender.objects.get_or_create(obj=project, owner=self.request.user, **form.clean())
+        project = get_object_or_404(models.Project, id=self.kwargs["pk"])
+        sender, created = models.Sender.objects.get_or_create(
+            obj=project,
+            **form.clean(),
+            defaults={"owner": self.request.user},
+        )
         signals.check_user_subscription(models.Sender, sender, created, self.request)
         return HttpResponseRedirect(project.get_absolute_url())
 
@@ -901,8 +905,12 @@ class ServiceNotifierRegister(LoginRequiredMixin, FormView, mixins.ServiceMixin)
     form_class = forms.SenderForm
 
     def form_valid(self, form):
-        service = get_object_or_404(models.Service, id=self.kwargs['pk'])
-        sender, created = models.Sender.objects.get_or_create(obj=service, owner=self.request.user, **form.clean())
+        service = get_object_or_404(models.Service, id=self.kwargs["pk"])
+        sender, created = models.Sender.objects.get_or_create(
+            obj=service,
+            **form.clean(),
+            defaults={"owner": self.request.user},
+        )
         signals.check_user_subscription(models.Sender, sender, created, self.request)
         return HttpResponseRedirect(service.get_absolute_url())
 


### PR DESCRIPTION
When using get_or_create, we want to ensure an owner, but we do not care
if someone else has ownership. Move our owner field to defaults to avoid a
duplicate sender in some cases.