### PR TITLE
[BUGFIX] Fix missing `load i18n` tag

### DIFF
--- a/promgen/templates/promgen/farm_detail.html
+++ b/promgen/templates/promgen/farm_detail.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load i18n %}
 
 {% block content %}
 

--- a/promgen/templates/promgen/host_form.html
+++ b/promgen/templates/promgen/host_form.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load i18n %}
 
 {% block content %}
 


### PR DESCRIPTION
A few updates from 1f821f1370f90248076e1f2ac8c903f014f46472 were missing the template load tag