### PR TITLE
Refresh the Home page when it's empty

### DIFF
--- a/promgen/templates/promgen/home.html
+++ b/promgen/templates/promgen/home.html
@@ -6,12 +6,17 @@
 {% include "promgen/service_header.html" %}
 {% include "promgen/service_block.html" %}
 {% empty %}
-<h3>No Subscriptions Found</h3>
-<p>
-  Try Subscribing to some notifications from the
-  <a href="{% url 'service-list' %}">Service</a> or
-  <a href="{% url 'datasource-list' %}">Datasource</a> menu
-  </p>
+<div class="page-header">
+  <h1>It seems you don't have any subscriptions yet!</h1>
+</div>
+<p class="lead">
+  Get started by subscribing to notifications from an existing
+  <a href="{% url 'service-list' %}">service</a> or check out the list of
+  <a href="{% url 'datasource-list' %}">data sources</a>.
+</p>
+<p class="lead">
+  Or, if you want, <a href="{% url 'service-new' %}">register</a> a new service.
+</p>
 {% endfor %}
 
 {% endblock %}


### PR DESCRIPTION
Before, when the Home page was empty it just included a small text linking to
the services and data sources.

Now it has a more friendly headline, a bigger font to improve readability, and a
new link for directly creating a service. This new link will save the user from
having to navigate to the "Services" page in order to create its first service.