### PR TITLE
Show rule description in rule page

### DIFF
--- a/promgen/templates/promgen/rule_detail.html
+++ b/promgen/templates/promgen/rule_detail.html
@@ -28,6 +28,12 @@ Promgen / Rule / {{ rule.name }}
 <div class="panel panel-primary">
     <div class="panel-heading">{{rule.name}}</div>
     <div class="panel-body">
+{% if rule.description %}
+        <div>
+            <label>Description:</label>
+            <p>{{rule.description}}</p>
+        </div>
+{% endif %}
         <pre v-pre>{{rule|rule_dict|pretty_yaml}}</pre>
     </div>
     <div class="panel-footer">


### PR DESCRIPTION
Before, when you wanted to see the description of a rule, you needed to edit it in order to load the form and then look at the description field. That was a little bit weird and could be considered as an anti pattern for good usability.

Now, since we have added the description to the `rule_dict` template tag, it is displayed in the rule detail page.