### PR TITLE
Fix DatasourceList view

### DIFF
--- a/promgen/templates/promgen/shard_list.html
+++ b/promgen/templates/promgen/shard_list.html
@@ -11,7 +11,7 @@
 {% breadcrumb label="Datasource" %}
 
 <div class="service-grid">
-  {% for shard in shard_list|dictsortreversed:"project_set.count" %}
+  {% for shard in shard_list|dictsortreversed:"num_projects" %}
   <div>
     <h2><a href="{% url 'datasource-detail' shard.id %}">{{ shard.name }}</a></h2>
     <a href="{{shard.url}}">{{shard.url}}</a>

--- a/promgen/views.py
+++ b/promgen/views.py
@@ -62,7 +62,7 @@ class DatasourceList(LoginRequiredMixin, ListView):
         "project_set__notifiers",
         "project_set__notifiers__owner",
         "prometheus_set",
-    )
+    ).annotate(num_projects=Count("project"))
 
 
 class DatasourceDetail(LoginRequiredMixin, DetailView):


### PR DESCRIPTION
The view was looping through the Shard objects using "project_set.count" as the argument for "dictsortreversed". This was causing an empty loop because "project_set.count" is not an attribute in the Shard objects.

"project_set" is a backwards relationship [1] created by Django, and "count" is a function that returns the number of objects in that relationship.

The reason why "project_set.count" was used in the view was to display the shards sorted by the number of projects, so the shards with most projects appear at the top, and the ones with less projects appear at the bottom.

To fix the issue we just create a "num_projects" annotation in the query that retrieves the shards, and use it as the argument for "dictsortreversed".

1: https://docs.djangoproject.com/en/dev/topics/db/queries/#backwards-related-objects