### PR TITLE
Allow testing notifiers before registering them

### DIFF
--- a/promgen/static/js/promgen.vue.js
+++ b/promgen/static/js/promgen.vue.js
@@ -282,8 +282,8 @@ const NotifierPreTestResult = Vue.component("notifier-pre-test-result", {
         <bootstrap-panel
             :class="{
                 'panel-info': state.result === 'success',
-                'panel-danger': state.result === 'error'}
-            "
+                'panel-danger': state.result === 'error',
+	    }"
             heading="Notifier test result"
             v-if="state.show"
         >

--- a/promgen/templates/promgen/profile.html
+++ b/promgen/templates/promgen/profile.html
@@ -78,6 +78,12 @@
             </table>
             <div class="panel-footer">
               <button class="btn btn-primary">Register Notifier</button>
+              <notifier-pre-test
+                class="btn btn-info"
+                href="{% url 'notifier-pre-test' %}"
+              >
+                {% trans "Test" %}
+              </notifier-pre-test>
             </div>
           </form>
         </div>
@@ -86,6 +92,10 @@
       </div>
     </div>
   </div>
+</div>
+
+<div>
+  <notifier-pre-test-result></notifier-pre-test-result>
 </div>
 
 {% if user.is_staff %}

--- a/promgen/urls.py
+++ b/promgen/urls.py
@@ -80,6 +80,7 @@ urlpatterns = [
     path("notifier/<int:pk>/test", views.NotifierTest.as_view(), name="notifier-test"),
     path("notifier/<int:pk>", views.NotifierUpdate.as_view(), name="notifier-edit"),
     path("notifier/<int:pk>/toggle", views.NotifierToggle.as_view(), name="notifier-toggle"),
+    path("notifier/pre-test", views.NotifierPreTest.as_view(), name="notifier-pre-test"),
     # Rules
     path("rule", views.RulesList.as_view(), name="rules-list"),
     path("rule/<int:pk>", views.RuleDetail.as_view(), name="rule-detail"),

--- a/promgen/views.py
+++ b/promgen/views.py
@@ -321,6 +321,28 @@ class NotifierDelete(LoginRequiredMixin, DeleteView):
         return reverse("profile")
 
 
+class NotifierPreTest(LoginRequiredMixin, View):
+    def post(self, request):
+        data = request.POST.dict()
+        sender = models.Sender(
+            sender=data.get("sender"),
+            value=data.get("value"),
+            alias=data.get("alias"),
+        )
+
+        try:
+            sender.test()
+        except Exception as e:
+            return JsonResponse({
+                "result": "error",
+                "msg": f"Error sending test message with {sender.sender}"
+            })
+        else:
+            return JsonResponse({
+                "result": "success",
+                "msg": f"Sent test message with {sender.sender}",
+            })
+
 class NotifierTest(LoginRequiredMixin, View):
     def post(self, request, pk):
         sender = get_object_or_404(models.Sender, id=pk)


### PR DESCRIPTION
This commit adds a new "Test" button next to the one for registering a notifier, so the user can use it to test if the notifier they are about to register actually works.

Example of success:

![Screenshot 2022-12-20 at 19-04-30 Promgen 0 57 0 dev](https://user-images.githubusercontent.com/6151586/208640566-6f5b7763-58b6-4669-9be4-d5f593e90288.png)

Example of error:

![Screenshot 2022-12-20 at 19-03-59 Promgen 0 57 0 dev](https://user-images.githubusercontent.com/6151586/208640600-196fe8c8-65ef-4ab2-ada8-8d9dcb4b2e06.png)
