### PR TITLE
[IMPROVEMENT] Rule Test should check for unrelated labels

### DIFF
--- a/promgen/templates/promgen/ajax_clause_check.html
+++ b/promgen/templates/promgen/ajax_clause_check.html
@@ -13,7 +13,7 @@
 </div>
 {% if data.result %}
     <table id="prometheus-query-results" class="table table-condensed table-scroll {% if collapse %}collapse{% endif %}">
-      <tr class="{{ status }}">
+      <tr class="{{ severity }}">
         <th>Timestamp</th>
         <th>Value</th>
         <th>Metric</th>
@@ -30,14 +30,14 @@
 
 {% if errors %}
     <table class="table table-condensed">
-      <tr class="{{ status }}">
+      <tr class="{{ severity }}">
         <th>Error</th>
         <th>Message</th>
       </tr>
 {% for error, message in errors.items %}
       <tr>
         <td>{{ error }}</td>
-        <td>{{ message }}</td>
+        <td>{{ message|linebreaks }}</td>
       </tr>
 {% endfor %}
   </table>


### PR DESCRIPTION
A common source of confusion when writing Rules, is the global namespace of Prometheus when on a shared server. It's very easy to write a rule that covers more projects than expected.

To help avoid this, we want to upgrade the rule test button to check the labels that are returned vs the expected labels.



This was code that was written months ago, but got delayed due to other infra tasks. It could probably be made more robust, but I think we're ultimately going to take a deeper look at the rules system in the near future.