### PR TITLE
Add debug warning to top of page

### DIFF
--- a/promgen/templates/base.html
+++ b/promgen/templates/base.html
@@ -15,6 +15,9 @@
 
 <body>
   <div id="vue">
+    {% if debug %}
+    <div class="alert alert-warning" role="alert">Currently in DEBUG Mode</div>
+    {% endif %}
     {% block navbar %}
     {% include "promgen/navbar.html" %}
     {% endblock %}


### PR DESCRIPTION
To make it easier to distinguish testing environment from a live one, we want to add an obvious warning alert at the top of the screen.

<img width="435" alt="スクリーンショット 2023-07-05 14 45 03" src="https://github.com/line/promgen/assets/89725/20c59f38-c2ac-4d92-accf-d80328a5612e">
