### PR TITLE
[BUGFIX] Fix missing celery redis

### DIFF
--- a/docker/requirements.in
+++ b/docker/requirements.in
@@ -2,3 +2,4 @@ gunicorn # Need gunicorn for running in docker
 # mysqlclient==1.4.1  # Installed manually for dependencies
 sentry_sdk<1.20.0 # Still using Sentry 9
 whitenoise # Need whitenoise for serving files
+celery[redis] # We want to allow redis by default

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -8,12 +8,16 @@ amqp==2.5.1
     # via kombu
 asgiref==3.4.1
     # via django
+async-timeout==4.0.2
+    # via redis
 atomicwrites==1.3.0
     # via promgen (setup.py)
 billiard==3.6.1.0
     # via celery
-celery==4.3.0
-    # via promgen (setup.py)
+celery[redis]==4.3.0
+    # via
+    #   -r docker/requirements.in
+    #   promgen (setup.py)
 certifi==2019.9.11
     # via
     #   requests
@@ -63,6 +67,8 @@ pytz==2021.3
     #   django
 pyyaml==6.0.1
     # via promgen (setup.py)
+redis==4.6.0
+    # via celery
 requests==2.25.1
     # via
     #   promgen (setup.py)


### PR DESCRIPTION
While updating the Python version in #429, our redis requirement was accidentally removed. We want to ensure the default container version can use redis.