### PR TITLE
[BUGFIX] Stricter checks about silencing global rules

### DIFF
--- a/promgen/errors.py
+++ b/promgen/errors.py
@@ -1,0 +1,17 @@
+from enum import Enum
+from django.utils.translation import gettext as _
+from django.core.exceptions import ValidationError
+
+
+class ValidationErrorEnum(Enum):
+    def error(self, **params):
+        params.setdefault("message", self.value)
+        params.setdefault("code", self.name)
+        return ValidationError(**params)
+
+
+class SilenceError(ValidationErrorEnum):
+    NOLABEL = _("Missing labels for silence.")
+    GLOBALSILENCE = _("Unable to silence global rules with alertname alone.")
+    STARTENDTIME = _("Both start and end are required.")
+    STARTENDMISMATCH = _("Start time and end time are mismatched.")

--- a/promgen/forms.py
+++ b/promgen/forms.py
@@ -3,12 +3,12 @@
 
 import re
 from functools import partial
+
 from dateutil import parser
-
-from promgen import models, plugins, prometheus, validators
-
 from django import forms
 from django.core.exceptions import ValidationError
+
+from promgen import models, plugins, prometheus, validators
 
 
 class ImportConfigForm(forms.Form):
@@ -43,7 +43,6 @@ class ImportRuleForm(forms.Form):
 
 
 class SilenceForm(forms.Form):
-
     duration = forms.CharField(required=False, validators=[validators.duration])
     startsAt = forms.CharField(required=False, validators=[validators.datetime])
     endsAt = forms.CharField(required=False, validators=[validators.datetime])
@@ -61,13 +60,32 @@ class SilenceForm(forms.Form):
         return "Promgen"
 
     def clean(self):
-        duration = self.data.get("duration")
-        start = self.data.get("startsAt")
-        stop = self.data.get("endsAt")
+        data = super().clean()
 
-        if duration:
+        # Validation for labels
+        if "labels" not in self.data or not self.data["labels"]:
+            raise forms.ValidationError("Unable to silence without labels")
+
+        # Users should not be able to accidentally silence a global rule without
+        # setting some other labels as well.
+        if "alertname" in self.data["labels"]:
+            if "service" not in self.data["labels"] and "project" not in self.data["labels"]:
+                rule = models.Rule.objects.get(name=self.data["labels"]["alertname"])
+                if rule.content_type.model == "site":
+                    raise forms.ValidationError(
+                        "Unable to silence global rules with alertname alone."
+                    )
+        # Once labels have been validated, we want to add them to our cleaned data so
+        # they can be submitted.
+        self.cleaned_data["labels"] = self.data["labels"]
+
+        if data.get("duration"):
             # No further validation is required if only duration is set
             return
+
+        # Validate our start/end times
+        start = data.get("startsAt")
+        stop = data.get("endsAt")
 
         if not all([start, stop]):
             raise forms.ValidationError("Both start and end are required")
@@ -148,6 +166,7 @@ class _KeyValueForm(forms.Form):
     key = forms.CharField(widget=forms.TextInput(attrs={"class": "form-control"}))
     value = forms.CharField(widget=forms.TextInput(attrs={"class": "form-control"}))
 
+
 # We need a custom KeyValueSet because we need to be able to convert between the single dictionary
 # form saved to our models, and the list of models used by
 class _KeyValueSet(forms.BaseFormSet):
@@ -158,6 +177,7 @@ class _KeyValueSet(forms.BaseFormSet):
 
     def to_dict(self):
         return {x["key"]: x["value"] for x in self.cleaned_data if x and not x["DELETE"]}
+
 
 # For both LabelFormSet and AnnotationFormSet we always want to have a prefix assigned, but it's
 # awkward if we need to specify it in multiple places. We use a partial here, so that it is the same

--- a/promgen/prometheus.py
+++ b/promgen/prometheus.py
@@ -261,11 +261,12 @@ def import_config(config, replace_shard=None):
     return counters, skipped
 
 
-def silence(labels, duration=None, **kwargs):
+def silence(*, labels, duration=None, **kwargs):
     """
     Post a silence message to Alert Manager
     Duration should be sent in a format like 1m 2h 1d etc
     """
+
     if duration:
         start = timezone.now()
         if duration.endswith("m"):

--- a/promgen/proxy.py
+++ b/promgen/proxy.py
@@ -210,7 +210,7 @@ class ProxySilences(View):
             )
 
         try:
-            response = prometheus.silence(body.pop("labels"), **form.cleaned_data)
+            response = prometheus.silence(**form.cleaned_data)
         except Exception as e:
             return JsonResponse(
                 {"messages": [{"class": "alert alert-danger", "message": str(e)}]},


### PR DESCRIPTION
Until we have a more robust permission system, we need to be cautious and ensure that users can not accidentally set a global level silence. To do this, we will check to see if the pending silence has alertname as a matcher, and if so, enforce that it also includes a service or project label.