### PR TITLE
[BUGFIX] Fix for rule prefetch on /search

### DIFF
--- a/promgen/views.py
+++ b/promgen/views.py
@@ -1134,7 +1134,7 @@ class Search(LoginRequiredMixin, View):
             "rule_list": {
                 "field": ("name__icontains", "clause__icontains"),
                 "model": models.Rule,
-                "prefetch": ("content_object"),
+                "prefetch": ("content_object",),
                 "query": ("search",),
             },
             "service_list": {


### PR DESCRIPTION
In f48218e3228ab625362c66811c11597381f0a872 we refactored how rules stored labels/annotations but when we updated this prefetch entry we accidentally changed it so that is no longer a proper tuple. This needs to be a tuple so that it does not try to treat each character as an entry.