### PR TITLE
[BUGFIX] Fix instance of Rule.add_label

### DIFF
--- a/promgen/views.py
+++ b/promgen/views.py
@@ -822,8 +822,8 @@ class AlertRuleRegister(mixins.PromgenPermissionMixin, mixins.RuleFormMixin, For
         return context
 
     def form_valid(self, form):
+        form.instance.labels[form.instance.content_type.model] = form.instance.content_object.name
         form.instance.save()
-        form.instance.add_label(form.instance.content_type.model, form.instance.content_object.name)
         return HttpResponseRedirect(form.instance.get_absolute_url())
 
     def form_import(self, form, content_object):


### PR DESCRIPTION
In 1454ed0466125a56dc2459617727d87950eb90af we migrated to JsonField for label and annotation storage, but one instance of add_label was missed.