### PR TITLE
[BUGFIX] Fix check for invalid annotation name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ demo:
 test: $(APP_BIN)
 ## Django: Run tests
 	$(APP_BIN) collectstatic --noinput
-	$(APP_BIN) test -v 2
+	$(APP_BIN) test -v 2 --buffer
 
 .PHONY: bootstrap
 ## Django: Bootstrap install

--- a/promgen/prometheus.py
+++ b/promgen/prometheus.py
@@ -42,9 +42,9 @@ def check_rules(rules):
         cmd = [util.setting("prometheus:promtool"), "check", "rules", fp.name]
 
         try:
-            subprocess.check_output(cmd, stderr=subprocess.STDOUT)
+            subprocess.check_output(cmd, stderr=subprocess.STDOUT, encoding="utf8")
         except subprocess.CalledProcessError as e:
-            raise ValidationError(rendered.decode("utf8") + e.output.decode("utf8"))
+            raise ValidationError(message=e.output + rendered.decode("utf8"))
 
 
 def render_rules(rules=None):

--- a/promgen/tests/test_alert_rules.py
+++ b/promgen/tests/test_alert_rules.py
@@ -129,9 +129,18 @@ class RuleTest(tests.PromgenTest):
 
     @override_settings(PROMGEN=TEST_SETTINGS)
     @mock.patch("django.dispatch.dispatcher.Signal.send")
-    def test_invalid_annotation(self, mock_post):
+    def test_invalid_annotation_value(self, mock_post):
         rule = models.Rule.objects.get(pk=1)
         # $label.foo is invalid (should be $labels) so make sure we raise an exception
         rule.annotations["summary"] = "{{$label.foo}}"
+        with self.assertRaises(ValidationError):
+            prometheus.check_rules([rule])
+
+    @override_settings(PROMGEN=TEST_SETTINGS)
+    @mock.patch("django.dispatch.dispatcher.Signal.send")
+    def test_invalid_annotation_name(self, mock_post):
+        rule = models.Rule.objects.get(pk=1)
+        # $label.foo is invalid (should be $labels) so make sure we raise an exception
+        rule.annotations["has a space"] = "value"
         with self.assertRaises(ValidationError):
             prometheus.check_rules([rule])

--- a/promgen/views.py
+++ b/promgen/views.py
@@ -781,6 +781,11 @@ class RuleUpdate(mixins.PromgenPermissionMixin, UpdateView):
         context["label_form"] = forms.LabelFormSet(data=request.POST)
         context["annotation_form"] = forms.AnnotationFormSet(data=request.POST)
 
+        # Before we validate the form, we also want to move our labels and annotations
+        # into our rule instance, so that they can be validated in the call to promtool
+        context["form"].instance.labels = context["label_form"].to_dict()
+        context["form"].instance.annotations = context["annotation_form"].to_dict()
+
         # With our labels+annotations manually cached we can test
         if not all(
             [
@@ -790,12 +795,6 @@ class RuleUpdate(mixins.PromgenPermissionMixin, UpdateView):
             ]
         ):
             return self.form_invalid(**context)
-
-        # After we validate that our forms are valid, we can just copy over the
-        # cleaned data into our instance so that it can be saved in the call to
-        # form_valid.
-        context["form"].instance.labels = context["label_form"].to_dict()
-        context["form"].instance.annotations = context["annotation_form"].to_dict()
 
         return self.form_valid(context["form"])
 


### PR DESCRIPTION
We need to ensure that our labels and annotations are also evaluated in the correct order when we call promtool to validate our rules.