### PR TITLE
[INTERNAL] Remove envdir

### DIFF
--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -30,6 +30,7 @@ jobs:
         run: make docs
         env:
           SYSTEM_PYTHON: python${{ matrix.python-version }}
+          SECRET_KEY: github-actions
 
       - name: Deploy to GitHub Pages
         if: ${{ github.ref == 'refs/heads/main' }}

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # https://github.com/django/django/blob/master/.gitignore
 
 .coverage
+.env
 .venv
 *.egg-info
 *.pyc

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ RUN pip install --no-cache-dir -e .
 USER promgen
 EXPOSE 8000
 
-RUN promgen collectstatic --noinput
+RUN SECRET_KEY=1 promgen collectstatic --noinput
 
 VOLUME ["/etc/promgen", "/etc/prometheus"]
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -44,8 +44,6 @@ django-filter==23.2
     # via promgen (setup.py)
 djangorestframework==3.14.0
     # via promgen (setup.py)
-envdir==1.0.1
-    # via promgen (setup.py)
 gunicorn==21.2.0
     # via -r docker/requirements.in
 idna==3.4

--- a/promgen/__init__.py
+++ b/promgen/__init__.py
@@ -16,27 +16,3 @@ PROMGEN_CONFIG_DIR = pathlib.Path(
 PROMGEN_CONFIG_FILE = pathlib.Path(
     os.environ.get("PROMGEN_CONFIG", str(PROMGEN_CONFIG_DIR / "promgen.yml"))
 )
-
-# In the future we want to remove the dependency on envdir, but this will
-# require some cleanup and documentation changes, so for now we will just
-# ensure that it can't fail here if envdir is not already installed
-if PROMGEN_CONFIG_DIR.exists():
-    try:
-        import envdir
-    except ImportError:
-        pass
-    else:
-        envdir.open(PROMGEN_CONFIG_DIR)
-
-
-if "SECRET_KEY" not in os.environ:
-    try:
-        from django.utils.crypto import get_random_string
-        import warnings
-
-        warnings.warn("Unset SECRET_KEY setting to random for now")
-        os.environ["SECRET_KEY"] = get_random_string(
-            50, "abcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*(-_=+)"
-        )
-    except ImportError:
-        pass

--- a/promgen/management/commands/bootstrap.py
+++ b/promgen/management/commands/bootstrap.py
@@ -61,9 +61,3 @@ class Command(BaseCommand):
             shutil.copy(PROMGEN_CONFIG_DEFAULT, PROMGEN_CONFIG_FILE)
         else:
             self.success("Config {} Exists", PROMGEN_CONFIG_FILE)
-
-        self.write("Checking environment settings", color=self.style.MIGRATE_HEADING)
-        self.setting("SECRET_KEY", default=settings.SECRET_KEY)
-        self.setting("DATABASE_URL")
-        self.setting("CELERY_BROKER_URL")
-        self.stdout.write("")

--- a/promgen/settings.py
+++ b/promgen/settings.py
@@ -32,7 +32,7 @@ DOT_ENV = BASE_DIR / ".env"
 # Load our environment
 env = environ.Env()
 if DOT_ENV.exists():
-    env.read_env(".env")
+    env.read_env(DOT_ENV)
 
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = env.str("SECRET_KEY")

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,6 @@ install_requires =
     django-filter
     Django~=3.2
     djangorestframework
-    envdir
     kombu
     prometheus-client
     python-dateutil


### PR DESCRIPTION
Since we have django-environ and we have been moving to a docker deployment, it doesn't make sense to keep envdir around anymore. This PR cleans up the initial bits, though we'll also have a future PR to cleanup the `promgen bootstrap` command more.