### PR TITLE
Convert Vue filters into methods

### DIFF
--- a/promgen/static/js/mixins.vue.js
+++ b/promgen/static/js/mixins.vue.js
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2023 LINE Corporation
+ * These sources are released under the terms of the MIT license: see LICENSE
+ */
+
+var mixins = {
+  methods: {
+    localize(number) {
+      return number.toLocaleString();
+    },
+  },
+};

--- a/promgen/static/js/mixins.vue.js
+++ b/promgen/static/js/mixins.vue.js
@@ -8,5 +8,8 @@ var mixins = {
     localize(number) {
       return number.toLocaleString();
     },
+    percent(number) {
+      return (number * 100).toLocaleString() + "%";
+    },
   },
 };

--- a/promgen/static/js/mixins.vue.js
+++ b/promgen/static/js/mixins.vue.js
@@ -11,5 +11,8 @@ var mixins = {
     percent(number) {
       return (number * 100).toLocaleString() + "%";
     },
+    urlize(value) {
+      return linkifyStr(value);
+    },
   },
 };

--- a/promgen/static/js/mixins.vue.js
+++ b/promgen/static/js/mixins.vue.js
@@ -14,5 +14,8 @@ var mixins = {
     urlize(value) {
       return linkifyStr(value);
     },
+    time(value, fmtstr = "yyyy-MM-dd HH:mm:ss") {
+      return luxon.DateTime.fromISO(value).toFormat(fmtstr);
+    },
   },
 };

--- a/promgen/static/js/promgen.vue.js
+++ b/promgen/static/js/promgen.vue.js
@@ -172,10 +172,6 @@ Vue.component('silence-form', {
     }
 });
 
-Vue.filter("time", function (value, fmtstr = "yyyy-MM-dd HH:mm:ss") {
-    return luxon.DateTime.fromISO(value).toFormat(fmtstr);
-});
-
 Vue.component("promql-query", {
     delimiters: ['[[', ']]'],
     props: ["href", "query", "max"],

--- a/promgen/static/js/promgen.vue.js
+++ b/promgen/static/js/promgen.vue.js
@@ -42,6 +42,7 @@ const app = new Vue({
     el: '#vue',
     delimiters: ['[[', ']]'],
     data: dataStore,
+    mixins: [mixins],
     methods: {
         toggleComponent: function (component) {
             let state = Boolean(this.components[component]);
@@ -169,10 +170,6 @@ Vue.component('silence-form', {
                 });
         },
     }
-});
-
-Vue.filter("urlize", function (value) {
-    return linkifyStr(value);
 });
 
 Vue.filter("time", function (value, fmtstr = "yyyy-MM-dd HH:mm:ss") {

--- a/promgen/static/js/promgen.vue.js
+++ b/promgen/static/js/promgen.vue.js
@@ -171,10 +171,6 @@ Vue.component('silence-form', {
     }
 });
 
-Vue.filter("localize", function (number) {
-    return number.toLocaleString();
-});
-
 Vue.filter("percent", function (number) {
     return (number * 100).toLocaleString() + "%"
 });
@@ -195,6 +191,7 @@ Vue.component("promql-query", {
             count: 0,
         };
     },
+    mixins: [mixins],
     computed: {
         load: function () {
             return this.count / Number.parseInt(this.max);

--- a/promgen/static/js/promgen.vue.js
+++ b/promgen/static/js/promgen.vue.js
@@ -171,10 +171,6 @@ Vue.component('silence-form', {
     }
 });
 
-Vue.filter("percent", function (number) {
-    return (number * 100).toLocaleString() + "%"
-});
-
 Vue.filter("urlize", function (value) {
     return linkifyStr(value);
 });

--- a/promgen/templates/base.html
+++ b/promgen/templates/base.html
@@ -52,6 +52,7 @@
     {% include 'promgen/vue/silence_form.html' %}
   </script>
   <script src="{% static 'js/promgen.js' %}"></script>
+  <script src="{% static 'js/mixins.vue.js' %}"></script>
   <script src="{% static 'js/promgen.vue.js' %}"></script>
   {% block javascript %}{% endblock %}
 

--- a/promgen/templates/promgen/alert_row.html
+++ b/promgen/templates/promgen/alert_row.html
@@ -15,7 +15,7 @@
         </dd>
         <template v-for="(value, annotation) in alert.annotations" class="dl-horizontal">
             <dt>[[annotation]]</dt>
-            <dd :inner-html.prop="value|urlize"></dd>
+            <dd v-html="urlize(value)"></dd>
         </template>
     </dl>
 </td>

--- a/promgen/templates/promgen/alert_row.html
+++ b/promgen/templates/promgen/alert_row.html
@@ -1,7 +1,7 @@
 {% load i18n %}
 
 <td class="col-xs-1">
-    <a :href="alert.generatorURL">[[alert.startsAt|time]]</a>
+    <a :href="alert.generatorURL">[[time(alert.startsAt)]]</a>
 </td>
 <td>
     <dl class="dl-horizontal">

--- a/promgen/templates/promgen/silence_row.html
+++ b/promgen/templates/promgen/silence_row.html
@@ -1,6 +1,6 @@
 {% load i18n %}
-<td class="col-xs-1">[[silence.startsAt|time]]</td>
-<td class="col-xs-1">[[silence.endsAt|time]]</td>
+<td class="col-xs-1">[[time(silence.startsAt)]]</td>
+<td class="col-xs-1">[[time(silence.endsAt)]]</td>
 <td class="col-xs-3 text-wrap">
     <ul class="list-inline">
         <li v-for="match in silence.matchers">

--- a/promgen/templates/promgen/silence_row.html
+++ b/promgen/templates/promgen/silence_row.html
@@ -10,7 +10,7 @@
         </li>
     </ul>
 </td>
-<td class="col-xs-3" :inner-html.prop="silence.comment|urlize"></td>
+<td class="col-xs-3" v-html="urlize(silence.comment)"></td>
 <td class="col-xs-3">[[silence.createdBy]]</td>
 
 <td style="col-xs-1">

--- a/promgen/templates/promgen/vue/promql_query.html
+++ b/promgen/templates/promgen/vue/promql_query.html
@@ -1,3 +1,3 @@
-<span style="display: none" :title="load | percent" :class="classes">
+<span style="display: none" :title="percent(load)" :class="classes">
   [[ localize(count) ]] <slot></slot>
 </span>

--- a/promgen/templates/promgen/vue/promql_query.html
+++ b/promgen/templates/promgen/vue/promql_query.html
@@ -1,3 +1,3 @@
 <span style="display: none" :title="load | percent" :class="classes">
-  [[ count | localize ]] <slot></slot>
+  [[ localize(count) ]] <slot></slot>
 </span>


### PR DESCRIPTION
In Vue 3, filters are removed and no longer supported. Instead, they recommend replacing them with method calls or computed properties.

https://v3-migration.vuejs.org/breaking-changes/filters.html

Since those methods can be reused in multiple components we store them as mixins instead of defining them in specific components. Mixins work in both Vue 2 and Vue 3.

The recommendation for migrating global filters in Vue 3 is to store them as global properties [1], however that is not supported in Vue 2.

1: https://vuejs.org/api/application.html#app-config-globalproperties

---

This PR will make the future PR for migrating to Vue 3 much shorter.