### PR TITLE
Fix github pages deploy

### DIFF
--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -44,7 +44,7 @@ jobs:
 
   deploy:
     needs: build
-    if: ${{ github.ref == 'refs/heads/master' }}
+    if: ${{ github.ref_name == github.event.repository.default_branch }}
 
     permissions:
       pages: write

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -7,8 +7,13 @@ on:
     branches:
       - master
 
+# Allow one concurrent deployment
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
 jobs:
-  docs:
+  build:
     name: Build Sphinx Documentation
     runs-on: ubuntu-20.04
 
@@ -32,10 +37,25 @@ jobs:
           SYSTEM_PYTHON: python${{ matrix.python-version }}
           SECRET_KEY: github-actions
 
-      - name: Deploy to GitHub Pages
-        if: ${{ github.ref == 'refs/heads/main' }}
-        uses: JamesIves/github-pages-deploy-action@v4.4.1
+      - name: Upload pages artifact
+        uses: actions/upload-pages-artifact@v2
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BRANCH: gh-pages
-          FOLDER: dist/html
+          path: 'dist/html'
+
+  deploy:
+    needs: build
+    if: ${{ github.ref == 'refs/heads/master' }}
+
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: production
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2
+


### PR DESCRIPTION
Closes #443 

- deploy with action artifacts, not from gh-pages branch
- check ref with master, not with main

ex) https://github.com/sh-cho/promgen/actions/runs/6706997395

Only deploy on push master branch (using [github actions context](https://docs.github.com/en/actions/learn-github-actions/contexts#determining-when-to-use-contexts))

`gh-pages` branch can be removed after this PR is merged