### PR TITLE
Remove readthedocs in favor of Github actions and gh-pages

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,3 +1,0 @@
-python:
-    extra_requirements:
-        - docs

--- a/promgen/templates/promgen/help_menu.inc.html
+++ b/promgen/templates/promgen/help_menu.inc.html
@@ -1,7 +1,7 @@
 <li class="dropdown">
     <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
     <ul class="dropdown-menu">
-        <li><a rel="noopener noreferrer" href="https://promgen.readthedocs.io/">Documentation</a></li>
+        <li><a rel="noopener noreferrer" href="https://line.github.io/promgen/">Documentation</a></li>
         <li><a rel="noopener noreferrer" href="https://github.com/line/promgen/releases">Changelog</a></li>
     </ul>
 </li>


### PR DESCRIPTION
In #444 the github actions was fixed to publish to gh-pages properly. Since our readthedocs build is current broken anyways, it is probably better to promote the github pages version as canotical since that will also result in less of a maintenance burden for other contributors.