### PR TITLE
Install graphviz package in sphinx workflow

### DIFF
--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -30,6 +30,9 @@ jobs:
             setup.cfg
             docker/requirements.txt
 
+      - name: Install graphviz
+        run: sudo apt-get install -y graphviz
+
       - name: Build Docs
         run: make docs
         env:


### PR DESCRIPTION
> WARNING: dot command 'dot' cannot be run (needed for graphviz output), check the graphviz_dot setting
> (in sphinx workflow log)

![image](https://github.com/line/promgen/assets/11611397/fa6c76f0-3a9e-4efb-bd19-a9d1c5618ed3)
(https://line.github.io/promgen/user/terms.html)

Dot graph is not displayed because graphviz package is not installed in workflow.

![image](https://github.com/line/promgen/assets/11611397/e811739c-c80a-4560-bff7-172ad00f6e03)

After install graphviz package, graph is rendered well (https://sh-cho.github.io/promgen/user/terms.html)