### PR TITLE
Add build pipeline for Primevue

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -39,7 +39,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v5.0.0
+        uses: docker/build-push-action@v5.1.0
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@
 build
 coverage.xml
 dist
+primevue-gen/node_modules
+package-lock.json
+promgen/static/primevue/
 
 # Prometheus/Docker ignores
 docker/promgen.json

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,8 +19,8 @@ The back end is written in Python. The front end has some parts that require a b
 ```bash
 # If you need to install Python or Node.js, try using your system's package manager
 # Examples
-# yum install python3 python3-pip nodejs
-# homebrew install python3
+# yum install python3 python3-pip nodejs # On RedHat
+# homebrew install python3 node # On MacOS
 # If using OSX with Homebrew, you may need to export some flags
 # to get mysql client to install
 # export LDFLAGS="-I/usr/local/opt/openssl/include -L/usr/local/opt/openssl/lib"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ You can see some of the commands by running `make help`
 If you are using an external database, you will want to create a `promgen` and `test_promgen`
 database before running bootstrap or `make migrate` and `make test` will fail.
 
-The back end is written in Python. The front end has some parts that require a build step, and for that Node.js is required.
+Promgen's backend is written in Python with parts of it's frontend written in Vuejs. Both Python and Node.js are required for development.
 
 ```bash
 # If you need to install Python or Node.js, try using your system's package manager

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ database before running bootstrap or `make migrate` and `make test` will fail.
 Promgen's backend is written in Python with parts of it's frontend written in Vuejs. Both Python and Node.js are required for development.
 
 ```bash
-# If you need to install Python or Node.js, try using your system's package manager
+# Python and Node.js can be installed with your system's package manager.
 # Examples
 # yum install python3 python3-pip nodejs # On RedHat
 # homebrew install python3 node # On MacOS

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,10 +14,12 @@ You can see some of the commands by running `make help`
 If you are using an external database, you will want to create a `promgen` and `test_promgen`
 database before running bootstrap or `make migrate` and `make test` will fail.
 
+The back end is written in Python. The front end has some parts that require a build step, and for that Node.js is required.
+
 ```bash
-# If you need to install Python first, try using your system's package manager
+# If you need to install Python or Node.js, try using your system's package manager
 # Examples
-# yum install python3 python3-pip
+# yum install python3 python3-pip nodejs
 # homebrew install python3
 # If using OSX with Homebrew, you may need to export some flags
 # to get mysql client to install
@@ -32,6 +34,8 @@ echo 1 > ~/.config/promgen/DEBUG
 make migrate
 # Run tests
 make test
+# Build front end
+make primevue
 # Run development server
 make run
 ```

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,13 @@
+# Build frontend
+FROM node:20.10.0-alpine as frontend-builder
+WORKDIR /build
+COPY primevue-gen ./primevue-gen
+RUN mkdir -p promgen/static
+RUN set -ex \
+    && cd primevue-gen \
+    && npm install \
+    && npm run build
+
 FROM python:3.9-alpine
 LABEL maintainer=paul.traylor@linecorp.com
 
@@ -44,6 +54,7 @@ COPY docker/docker-entrypoint.sh /
 COPY setup.py /usr/src/app/setup.py
 COPY setup.cfg /usr/src/app/setup.cfg
 COPY promgen /usr/src/app/promgen
+COPY --from=frontend-builder /build/promgen/static/primevue /usr/src/app/promgen/static/primevue
 COPY promgen/tests/examples/promgen.yml /etc/promgen/promgen.yml
 
 WORKDIR /usr/src/app

--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,7 @@ migrate: $(APP_BIN)
 
 .PHONY:	run
 ## Django: Run development server
-run: migrate
+run: migrate primevue
 	$(APP_BIN) runserver
 
 .PHONY: shell
@@ -163,3 +163,12 @@ clean:
 .PHONY: changelog
 changelog:
 	git log --color=always --first-parent --pretty='format:%s|%Cgreen%d%Creset' | column -ts '|' | less "$(lessopts)"
+
+.PHONY: primevue
+primevue: primevue-gen/node_modules promgen/static/primevue/main.css promgen/static/primevue/main.js
+
+primevue-gen/node_modules: primevue-gen/package.json
+	cd primevue-gen && npm i --no-package-lock
+
+promgen/static/primevue/main.css promgen/static/primevue/main.js: primevue-gen/build.js primevue-gen/src/main.js
+	cd primevue-gen && npm run build

--- a/primevue-gen/build.js
+++ b/primevue-gen/build.js
@@ -1,0 +1,30 @@
+// https://esbuild.github.io/plugins/#using-plugins
+
+const esbuild = require("esbuild");
+
+const myPlugin = {
+  name: "my-plugin",
+  setup(build) {
+    build.onResolve({ filter: /^vue$/ }, (args) => ({
+      path: args.path,
+      namespace: "my-plugin",
+    }));
+
+    build.onLoad({ filter: /.*/, namespace: "my-plugin" }, () => ({
+      contents: "module.exports = Vue",
+    }));
+  },
+};
+(async () => {
+  await esbuild.build({
+    entryPoints: ["./src/main.js"],
+    bundle: true,
+    outdir: "../promgen/static/primevue",
+    logLevel: "info",
+    loader: {
+      ".woff2": "dataurl",
+    },
+    plugins: [myPlugin],
+    minify: true,
+  });
+})();

--- a/primevue-gen/package.json
+++ b/primevue-gen/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "primvue-gen",
+  "version": "1.0.0",
+  "description": "",
+  "scripts": {
+    "build": "node build.js"
+  },
+  "keywords": [],
+  "author": "",
+  "dependencies": {
+    "primevue": "3.40.1"
+  },
+  "devDependencies": {
+    "esbuild": "0.19.5"
+  }
+}

--- a/primevue-gen/src/main.js
+++ b/primevue-gen/src/main.js
@@ -1,0 +1,10 @@
+import Vue from "vue";
+import PrimeVue from "primevue/config";
+import "primevue/resources/themes/bootstrap4-light-blue/theme.css";
+
+window.createPrimeVueApp = function (opt) {
+  const app = Vue.createApp(opt);
+  app.use(PrimeVue);
+
+  return app;
+};

--- a/promgen/static/js/promgen.vue.js
+++ b/promgen/static/js/promgen.vue.js
@@ -46,7 +46,7 @@ const exporterTestResultStore = Vue.reactive({
     },
 });
 
-const app = Vue.createApp({
+const app = createPrimeVueApp({
     delimiters: ['[[', ']]'],
     data() {
         return dataStore;

--- a/promgen/templates/base.html
+++ b/promgen/templates/base.html
@@ -11,6 +11,13 @@
   <link rel="stylesheet" href="{% static 'css/bootstrap-switch.min.css' %}">
   <link rel="stylesheet" href="{% static 'css/promgen.css' %}">
   <link rel="icon" href="{% static 'images/promgen_logo_color.png' %}">
+  {% if debug %}
+  <script src="{% static 'js/vue-3.3.7/vue.global.js' %}"></script>
+  {% else %}
+  <script src="{% static 'js/vue-3.3.7/vue.global.prod.js' %}"></script>
+  {% endif %}
+  <script src="{% static 'primevue/main.js' %}"></script>
+  <link rel="stylesheet" href="{% static 'primevue/main.css' %}" />
 </head>
 
 <body>
@@ -35,11 +42,6 @@
   <script src="{% static 'js/luxon.min.js' %}"></script>
   <script src="{% static 'js/linkify.min.js' %}"></script>
   <script src="{% static 'js/linkify-string.min.js' %}"></script>
-  {% if debug %}
-  <script src="{% static 'js/vue-3.3.7/vue.global.js' %}"></script>
-  {% else %}
-  <script src="{% static 'js/vue-3.3.7/vue.global.prod.js' %}"></script>
-  {% endif %}
   <script type="text/x-template" id="bootstrap-panel-template">
     {% include 'promgen/vue/bootstrap_panel.html' %}
   </script>


### PR DESCRIPTION
This PR shows the build pipeline for [Primevue](https://primevue.org/)
Before try to use the new components, we need to import them first in `promgen-gen/main.js`
Then run `make primevue` command.
After the new file is generated under `static/promgen`. You can start to use the new components!
