### PR TITLE
Fix Promgen init documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ chmod 777 ~/.config/promgen
 # using the standard DSN syntax.
 # Database example: mysql://username:password@hostname/databasename
 # Broker example: redis://localhost:6379/0
-docker run --rm -it -v ~/.config/promgen:/etc/promgen/ line/promgen bootstrap
+docker run --rm -it -v ~/.config/promgen:/etc/promgen/ line/promgen docker-compose-bootstrap
 
 # Apply database updates
 docker run --rm -v ~/.config/promgen:/etc/promgen/ line/promgen migrate


### PR DESCRIPTION
Value of case is **docker-compose-boostrap** not **boostrap**
https://github.com/line/promgen/blob/master/docker/docker-entrypoint.sh#L10