### PR TITLE
notification/webhook: Add alias field

### DIFF
--- a/promgen/notification/webhook.py
+++ b/promgen/notification/webhook.py
@@ -22,6 +22,10 @@ class FormWebhook(forms.Form):
         required=True,
         label="URL",
     )
+    alias = forms.CharField(
+        required=False,
+        help_text="Optional description to be displayed instead of the URL.",
+    )
 
 
 class NotificationWebhook(NotificationBase):


### PR DESCRIPTION
In the same way that is done for the other notifiers, we have added an alias field to prevent secret tokens to be leaked when displaying the notifier's description in the UI.