### PR TITLE
promgen.vue.js: Fix silence form's delete label

### DIFF
--- a/promgen/static/js/promgen.vue.js
+++ b/promgen/static/js/promgen.vue.js
@@ -158,7 +158,7 @@ app.component('silence-form', {
     }),
     methods: {
         removeLabel(label) {
-            this.$delete(this.state.labels, label);
+            delete this.state.labels[label];
         },
         submit() {
             const body = JSON.stringify({


### PR DESCRIPTION
Before creating the silence, the silence form appears and we have the possibility to remove any labels that were added by default. When doing so, an error like this one happens:

  TypeError: this.$delete is not a function

The error occurs because the "$delete" instance method [1] has been removed in Vue 3 [2], but we forgot to adapt this part of the code when we did the migration.

1: https://v2.vuejs.org/v2/api/#vm-delete
2: https://v3-migration.vuejs.org/breaking-changes/#removed-apis