### PR TITLE
models.py: Rule: Check content_object before accessing it

### DIFF
--- a/promgen/models.py
+++ b/promgen/models.py
@@ -422,7 +422,11 @@ class Rule(models.Model):
         ordering = ["content_type", "object_id", "name"]
 
     def __str__(self):
-        return f"{self.name} [{self.content_object.name}]"
+        return (
+            f"{self.name}"
+            if self.content_object is None
+            else f"{self.name} [{self.content_object.name}]"
+        )
 
     def get_absolute_url(self):
         return reverse("rule-detail", kwargs={"pk": self.pk})


### PR DESCRIPTION
We have noticed that deleting projects that contain rules throw an error than can be seen on user's side as an "Internal Error!" page.

This occurs because the rule's "content_object.name" is trying to be accessed after the project has been deleted, therefore "content_object" is None and does not contain a "name" member.