### PR TITLE
[BUGFIX] Stricter validation

### DIFF
--- a/promgen/tests/test_models.py
+++ b/promgen/tests/test_models.py
@@ -4,7 +4,7 @@
 
 from django.core.exceptions import ValidationError
 
-from promgen import models
+from promgen import models, validators
 from promgen.tests import PromgenTest
 
 
@@ -23,3 +23,14 @@ class ModelTest(PromgenTest):
             # Fail a name with \
             models.Service(name=r"foo/bar", owner=self.user).full_clean()
             models.Service(name=r"foo\bar", owner=self.user).full_clean()
+
+    def test_validators(self):
+        with self.assertRaises(ValidationError, msg="Javascript injection"):
+            validators.metricname(
+                "asdasd[[1-1]]')) || (this.$el.ownerDocument.defaultView.alert('1337",
+            )
+
+        with self.assertRaises(ValidationError, msg="Vue.js injection"):
+            validators.metricname(
+                "[[this.$el.ownerDocument.defaultView.alert(1337)]]",
+            )

--- a/promgen/validators.py
+++ b/promgen/validators.py
@@ -19,14 +19,18 @@ duration = RegexValidator(
 # Label Value Definition
 # https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels
 metricname = RegexValidator(
-    r"[a-zA-Z_:][a-zA-Z0-9_:]*", "Only alphanumeric characters are allowed."
+    r"^[a-zA-Z_:][a-zA-Z0-9_:]*$",
+    "Only alphanumeric characters are allowed.",
 )
-labelname = RegexValidator(r"[a-zA-Z_][a-zA-Z0-9_]*", "Only alphanumeric characters are allowed.")
+labelname = RegexValidator(
+    r"^[a-zA-Z_][a-zA-Z0-9_]*$",
+    "Only alphanumeric characters are allowed.",
+)
 
 # While Prometheus accepts label values of any unicode character, our values sometimes
 # make it into URLs, so we want to make sure we do not have stray / characters
 labelvalue = RegexValidator(
-    r"^[\w][- \w]+\Z", "Unicode letters, numbers, underscores, or hyphens or spaces"
+    r"^[\w][- \w]+$", "Unicode letters, numbers, underscores, or hyphens or spaces"
 )
 
 hostname = RegexValidator(


### PR DESCRIPTION
Previously some of our regex checks were not properly bounded. By adding ^ and $ to our regex, we can ensure the entire string gets checked.