### PR TITLE
[IMPROVEMENT] Update to Alertmanager v2 API

### DIFF
--- a/promgen/static/js/promgen.vue.js
+++ b/promgen/static/js/promgen.vue.js
@@ -86,7 +86,7 @@ const app = Vue.createApp({
             fetch('/proxy/v1/silences')
                 .then(response => response.json())
                 .then(response => {
-                    let silences = response.data.sort(silence => silence.startsAt);
+                    let silences = response.sort(silence => silence.startsAt);
 
                     // Pull out the matchers and do a simpler label map
                     // to make other code easier
@@ -104,7 +104,7 @@ const app = Vue.createApp({
             fetch('/proxy/v1/alerts')
                 .then(response => response.json())
                 .then(response => {
-                    this.globalAlerts = response.data.sort(alert => alert.startsAt);
+                    this.globalAlerts = response.sort(alert => alert.startsAt);
                 });
 
         },

--- a/promgen/tests/__init__.py
+++ b/promgen/tests/__init__.py
@@ -29,6 +29,7 @@ class Data:
 
 class PromgenTest(TestCase):
     longMessage = True
+    maxDiff = None
     fixtures = ["testcases.yaml"]
 
     def fireAlert(self, source="alertmanager.json", data=None):

--- a/promgen/tests/examples/silence.duration.json
+++ b/promgen/tests/examples/silence.duration.json
@@ -3,8 +3,10 @@
     "matchers": [{
         "value": "example.com:[0-9]*",
         "isRegex": true,
+        "isEqual": true,
         "name": "instance"
     }],
     "comment": "Silenced from Promgen",
+    "startsAt": "2017-12-14T00:00:00+00:00",
     "endsAt": "2017-12-14T00:01:00+00:00"
 }

--- a/promgen/tests/examples/silence.range.json
+++ b/promgen/tests/examples/silence.range.json
@@ -3,6 +3,7 @@
   "matchers": [{
     "value": "example.com:[0-9]*",
     "isRegex": true,
+    "isEqual": true,
     "name": "instance"
   }],
   "comment": "Silenced from Promgen",

--- a/promgen/tests/test_silence.py
+++ b/promgen/tests/test_silence.py
@@ -41,8 +41,8 @@ class SilenceTest(tests.PromgenTest):
                 },
                 content_type="application/json",
             )
-        self.assertMockCalls(
-            mock_post, "http://alertmanager:9093/api/v1/silences", json=TEST_DURATION
+        mock_post.assert_called_with(
+            "http://alertmanager:9093/api/v2/silences", json=TEST_DURATION
         )
 
     @override_settings(PROMGEN=TEST_SETTINGS)
@@ -62,7 +62,9 @@ class SilenceTest(tests.PromgenTest):
                 content_type="application/json",
             )
 
-        self.assertMockCalls(mock_post, "http://alertmanager:9093/api/v1/silences", json=TEST_RANGE)
+        mock_post.assert_called_with(
+            "http://alertmanager:9093/api/v2/silences", json=TEST_RANGE
+        )
 
     @override_settings(PROMGEN=TEST_SETTINGS)
     def test_site_silence_errors(self):


### PR DESCRIPTION
For most things, changing v1 to v2 works.

The silence API now expects startsAt for all requests, so we make that adjustment.

The Alerts and Silences API now return directly instead of a data field so we also make that adjustment.

Also do some minor adjustments to use HTTPStatus instead of hardcoded status codes.