### PR TITLE
[BUGFIX] Fix notification splay

### DIFF
--- a/promgen/notification/user.py
+++ b/promgen/notification/user.py
@@ -37,13 +37,13 @@ class NotificationUser(NotificationBase):
 
     form = FormUser
 
-    def splay(self, address):
+    def splay(self, address, **kwargs):
         try:
             user = User.objects.get(username=address)
         except User.DoesNotExist:
             logger.error("Missing user %s", address)
         else:
-            yield from models.Sender.objects.filter(obj=user)
+            yield from models.Sender.objects.filter(obj=user, **kwargs)
 
     def _send(self, address, data):
         user = User.objects.get(username=address)

--- a/promgen/signals.py
+++ b/promgen/signals.py
@@ -312,6 +312,7 @@ def check_user_subscription(sender, instance, created, request):
 
 
 @receiver(post_save, sender=models.Service)
+@skip_raw
 def add_default_service_subscription(instance, created, **kwargs):
     if created and instance.owner:
         sender, new_notifier = models.Sender.objects.get_or_create(
@@ -323,6 +324,7 @@ def add_default_service_subscription(instance, created, **kwargs):
 
 
 @receiver(post_save, sender=models.Project)
+@skip_raw
 def add_default_project_subscription(instance, created, **kwargs):
     if created and instance.owner:
         sender, new_notifier = models.Sender.objects.get_or_create(

--- a/promgen/tasks.py
+++ b/promgen/tasks.py
@@ -60,7 +60,7 @@ def process_alert(alert_pk):
                 logger.debug("Filtered out sender %s", sender)
                 continue
             if hasattr(sender.driver, "splay"):
-                for splay in sender.driver.splay(sender.value):
+                for splay in sender.driver.splay(sender.value, enabled=True):
                     senders[splay.sender].add(splay.value)
             else:
                 senders[sender.sender].add(sender.value)


### PR DESCRIPTION
Previously when checking the extra values, we never passed along our enabled query, so that child notifiers would always trigger even if they were disabled.