### PR TITLE
[BUGFIX] Use additional v-pre tags to avoid issues with user input.

### DIFF
--- a/promgen/settings.py
+++ b/promgen/settings.py
@@ -66,6 +66,7 @@ INSTALLED_APPS = apps_from_setuptools + [
     "rest_framework",
     "social_django",
     # Django
+    "django.forms",
     "django.contrib.admin",
     "django.contrib.auth",
     "django.contrib.contenttypes",
@@ -116,6 +117,7 @@ TEMPLATES = [
         },
     },
 ]
+FORM_RENDERER = "django.forms.renderers.TemplatesSetting"
 
 WSGI_APPLICATION = "promgen.wsgi.application"
 

--- a/promgen/templates/django/forms/widgets/textarea.html
+++ b/promgen/templates/django/forms/widgets/textarea.html
@@ -1,0 +1,2 @@
+<textarea v-pre name="{{ widget.name }}"{% include "django/forms/widgets/attrs.html" %}>
+    {% if widget.value %}{{ widget.value }}{% endif %}</textarea>

--- a/promgen/templates/promgen/project_detail_configuration.html
+++ b/promgen/templates/promgen/project_detail_configuration.html
@@ -52,7 +52,7 @@
 
   {% if project.description %}
 
-  <div class="panel-body">
+  <div v-pre class="panel-body">
     {{project.description|linebreaksbr|urlize}}
   </div>
 

--- a/promgen/templates/promgen/rule_detail.html
+++ b/promgen/templates/promgen/rule_detail.html
@@ -31,7 +31,7 @@ Promgen / Rule / {{ rule.name }}
 {% if rule.description %}
         <div>
             <label>Description:</label>
-            <p>{{rule.description}}</p>
+            <p v-pre>{{rule.description}}</p>
         </div>
 {% endif %}
         <pre v-pre>{{rule|rule_dict|pretty_yaml}}</pre>

--- a/promgen/templates/promgen/service_block.html
+++ b/promgen/templates/promgen/service_block.html
@@ -25,7 +25,7 @@
 
   {% if service.description %}
   <div class="panel panel-default">
-    <div class="panel-body">
+    <div v-pre class="panel-body">
       {{service.description|linebreaksbr|urlize}}
     </div>
   </div>


### PR DESCRIPTION
We want to add v-pre automatically to all text area tags, since those are often used for general user descriptions.
We also add v-pre tags for other areas where an objects .description tag might be rendered.