### PR TITLE
templates: Add v-pre to protect against XSS

### DIFF
--- a/promgen/templates/base.html
+++ b/promgen/templates/base.html
@@ -5,7 +5,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>{% block title %}Promgen {{ VERSION }}{% endblock %}</title>
+  <title v-pre>{% block title %}Promgen {{ VERSION }}{% endblock %}</title>
   <link rel="stylesheet" href="{% static 'css/bootstrap.min.css' %}">
   <link rel="stylesheet" href="{% static 'css/bootstrap-theme.min.css' %}">
   <link rel="stylesheet" href="{% static 'css/bootstrap-switch.min.css' %}">

--- a/promgen/templates/promgen/ajax_clause_check.html
+++ b/promgen/templates/promgen/ajax_clause_check.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 {% load promgen %}
-<div id="ajax-clause-check" class="panel panel-info">
+<div id="ajax-clause-check" class="panel panel-info" v-pre>
   <div class="panel-heading">Query Result</div>
   <div class="panel-body">
   <p>Query Duration: {{ duration }}</p>

--- a/promgen/templates/promgen/ajax_exporter.html
+++ b/promgen/templates/promgen/ajax_exporter.html
@@ -1,4 +1,4 @@
-<div id="{{target}}" class="panel panel-default">
+<div id="{{target}}" class="panel panel-default" v-pre>
   <table class="table">
     <tr>
       <th>URL</th>

--- a/promgen/templates/promgen/alert_detail.html
+++ b/promgen/templates/promgen/alert_detail.html
@@ -6,7 +6,7 @@
 
 <ul class="list-unstyled">
     {% for error in alert.alerterror_set.all %}
-    <li class="alert alert-danger" role="alert">
+    <li class="alert alert-danger" role="alert" v-pre>
         <span class="glyphicon glyphicon-alert" aria-hidden="true"></span>
         {{error.message}}
         <span class="pull-right">{{error.created}}</span>
@@ -17,9 +17,9 @@
 <h2>Routing</h2>
 <dl class="dl-horizontal">
     {% for label, value in groupLabels.items %}
-    <dt>{{label}}</dt>
+    <dt v-pre>{{label}}</dt>
     <dd>
-        <a class="label label-warning" href="{% url 'alert-list' %}?{{label}}={{value}}">{{value}}</a>
+        <a class="label label-warning" href="{% url 'alert-list' %}?{{label}}={{value}}" v-pre>{{value}}</a>
         {% if label in redirects %}
         <a href="{% url 'search' %}?var-{{label}}={{value}}">Search</a>
         {% endif %}
@@ -34,9 +34,9 @@
 <h2>Additional Common Labels</h2>
 <dl class="dl-horizontal">
     {% for label, value in otherLabels.items %}
-    <dt>{{label}}</dt>
+    <dt v-pre>{{label}}</dt>
     <dd>
-        <a class="label label-warning" href="{% url 'alert-list' %}?{{label}}={{value}}">{{value}}</a>
+        <a class="label label-warning" href="{% url 'alert-list' %}?{{label}}={{value}}" v-pre>{{value}}</a>
         {% if label in redirects %}
         <a href="{% url 'search' %}?var-{{label}}={{value}}">Search</a>
         {% endif %}
@@ -47,12 +47,12 @@
 <h2>Common Annotations</h2>
 <dl class="dl-horizontal">
     {% for label, value in data.commonAnnotations.items %}
-    <dt>{{label}}</dt>
-    <dd>{{value|urlize}}</dd>
+    <dt v-pre>{{label}}</dt>
+    <dd v-pre>{{value|urlize}}</dd>
     {% endfor %}
     {% if data.externalURL %}
     <dt>External URL</dt>
-    <dd>{{data.externalURL|urlizetrunc:100}}</dd>
+    <dd v-pre>{{data.externalURL|urlizetrunc:100}}</dd>
     {% endif %}
 </dl>
 
@@ -65,21 +65,21 @@
     </tr>
     {% for alert in data.alerts %}
     <tr>
-        <td>{{alert.startsAt}}</td>
+        <td v-pre>{{alert.startsAt}}</td>
         <td>
             <ul>
                 {% for k,v in alert.labels.items|dictsort:0 %}
-                <a class="label label-warning" href="{% url 'alert-list' %}?{{k}}={{v}}">{{k}}:{{v}}</a>
+                <a class="label label-warning" href="{% url 'alert-list' %}?{{k}}={{v}}" v-pre>{{k}}:{{v}}</a>
                 {% endfor %}
             </ul>
         </td>
-        <td>{{alert.generatorURL|urlizetrunc:100}}</td>
+        <td v-pre>{{alert.generatorURL|urlizetrunc:100}}</td>
     </tr>
     {% endfor %}
 </table>
 
 <details>
     <summary>Raw Data</summary>
-    <pre>{{alert.json|pretty_json}}</pre>
+    <pre v-pre>{{alert.json|pretty_json}}</pre>
 </details>
 {% endblock %}

--- a/promgen/templates/promgen/alert_list.html
+++ b/promgen/templates/promgen/alert_list.html
@@ -26,16 +26,16 @@
     {% for alert in alert_list %}
     {% ifchanged alert.created|date %}
     <tr class="table-secondary">
-        <th colspan="8">{{ alert.created|date }}</th>
+        <th colspan="8" v-pre>{{ alert.created|date }}</th>
     </tr>
     {% endifchanged %}
     <tr>
-        <td><a href="{{alert.get_absolute_url}}">{{ alert.created|timezone:TIMEZONE }}</a></td>
-        <td><a href="?alertname={{alert.json.commonLabels.alertname}}">{{alert.json.commonLabels.alertname}}</a></td>
-        <td>{{alert.json.commonLabels.datasource}}</td>
-        <td><a href="?service={{alert.json.commonLabels.service}}">{{alert.json.commonLabels.service}}</a></td>
-        <td><a href="?project={{alert.json.commonLabels.project}}">{{alert.json.commonLabels.project}}</a></td>
-        <td><a href="?job={{alert.json.commonLabels.job}}">{{alert.json.commonLabels.job}}</a></td>
+        <td><a href="{{alert.get_absolute_url}}" v-pre>{{ alert.created|timezone:TIMEZONE }}</a></td>
+        <td><a href="?alertname={{alert.json.commonLabels.alertname}}" v-pre>{{alert.json.commonLabels.alertname}}</a></td>
+        <td v-pre>{{alert.json.commonLabels.datasource}}</td>
+        <td><a href="?service={{alert.json.commonLabels.service}}" v-pre>{{alert.json.commonLabels.service}}</a></td>
+        <td><a href="?project={{alert.json.commonLabels.project}}" v-pre>{{alert.json.commonLabels.project}}</a></td>
+        <td><a href="?job={{alert.json.commonLabels.job}}" v-pre>{{alert.json.commonLabels.job}}</a></td>
         <td {% if alert.sent_count == 0 %}class="warning" {% endif %}>{{alert.sent_count}}</td>
         <td {% if alert.error_count %}class="danger" {% endif %}>{{alert.error_count}}</td>
     </tr>

--- a/promgen/templates/promgen/audit_list.html
+++ b/promgen/templates/promgen/audit_list.html
@@ -7,7 +7,7 @@
 </div>
 
 {% if request.GET %}
-<ul class="list-inline">
+<ul class="list-inline" v-pre>
   <li>Filters</li>
 {% for k in request.GET %}
 <li>
@@ -19,7 +19,7 @@
 </ul>
 {% endif %}
 
-<div class="panel panel-default">
+<div class="panel panel-default" v-pre>
     <table class="table table-bordered table-condensed">
       <thead>
         <tr>

--- a/promgen/templates/promgen/error_block.html
+++ b/promgen/templates/promgen/error_block.html
@@ -1,5 +1,5 @@
 {% for error in warning %}
-<div class="alert alert-warning alert-dismissible" role="alert">
+<div class="alert alert-warning alert-dismissible" role="alert" v-pre>
     <span class="glyphicon glyphicon-alert" aria-hidden="true"></span>
     <span class="sr-only">Warning:</span>
     <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
@@ -7,7 +7,7 @@
 </div>
 {% endfor %}
 {% for error in danger %}
-<div class="alert alert-danger alert-dismissible" role="alert">
+<div class="alert alert-danger alert-dismissible" role="alert" v-pre>
     <span class="glyphicon glyphicon-alert" aria-hidden="true"></span>
     <span class="sr-only">Warning:</span>
     <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>

--- a/promgen/templates/promgen/exporter_form.html
+++ b/promgen/templates/promgen/exporter_form.html
@@ -3,7 +3,7 @@
 {% load promgen %}
 {% block content %}
 
-<div class="page-header">
+<div class="page-header" v-pre>
   <h1>Project: {{ project.name }}</h1>
 </div>
 
@@ -31,7 +31,7 @@
             If there are no other job names that make sense, <strong class="text-success">app</strong> can be used as a general substitute
           </p>
         </div>
-        <table class="table">
+        <table class="table" v-pre>
           {{ form.as_table }}
         </table>
         <div class="panel-footer">
@@ -59,7 +59,7 @@
           <input type="hidden" name="scheme" value="{{ default.scheme }}" />
           <input type="hidden" name="enabled" value="1" />
           <div class="input-group-btn">
-            <button style="width:80%" class="btn btn-primary">Register {{ default.job }} :{{ default.port }}{{ default.path }}</button>
+            <button style="width:80%" class="btn btn-primary" v-pre>Register {{ default.job }} :{{ default.port }}{{ default.path }}</button>
             <exporter-test class="btn btn-info" href="{% url 'exporter-scrape' project.id %}">
               {% trans "Test" %}
             </exporter-test>

--- a/promgen/templates/promgen/farm_detail.html
+++ b/promgen/templates/promgen/farm_detail.html
@@ -3,17 +3,17 @@
 
 {% block content %}
 
-<div class="page-header">
+<div class="page-header" v-pre>
   <h1>Farm: {{ farm.name }} ({{ farm.source }})</h1>
 </div>
 
-<ol class="breadcrumb">
+<ol class="breadcrumb" v-pre>
   <li><a href="{% url 'service-list' %}">Home</a></li>
   <li><a href="{% url 'farm-list' %}">Farms</a></li>
   <li class="active"><a href="{% url 'farm-detail' farm.id %}">{{ farm.name }}</a></li>
 </ol>
 
-<div class="row">
+<div class="row" v-pre>
 
 <div class="col-md-6">
   <div class="panel panel-default">

--- a/promgen/templates/promgen/farm_duplicate.html
+++ b/promgen/templates/promgen/farm_duplicate.html
@@ -7,7 +7,7 @@
   <li class="active">Convert Farm</li>
 </ol>
 
-<div class="panel panel-warning">
+<div class="panel panel-warning" v-pre>
   <div class="panel-heading">Error converting farm. Duplicate detected</div>
 
   <table class="table">

--- a/promgen/templates/promgen/farm_form.html
+++ b/promgen/templates/promgen/farm_form.html
@@ -2,18 +2,18 @@
 
 {% block content %}
 
-<div class="page-header">
+<div class="page-header" v-pre>
   <h1>Project: {{ project.name }}</h1>
 </div>
 
-<ol class="breadcrumb">
+<ol class="breadcrumb" v-pre>
   <li><a href="{% url 'service-list' %}">Home</a></li>
   <li><a href="{% url 'service-detail' project.service.id %}">{{ project.service.name }}</a></li>
   <li><a href="{% url 'project-detail' project.id %}">{{ project.name }}</a></li>
   <li class="active">{{ view.button_label }}</li>
 </ol>
 
-<form method="post">{% csrf_token %}
+<form method="post" v-pre>{% csrf_token %}
     {{ form.as_p }}
     <button class="btn btn-primary">{{ view.button_label }}</button>
 </form>

--- a/promgen/templates/promgen/farm_list.html
+++ b/promgen/templates/promgen/farm_list.html
@@ -12,7 +12,7 @@
 
 {% include "promgen/pagination.html" %}
 
-<div class="panel panel-default">
+<div class="panel panel-default" v-pre>
   <table class="table table-bordered table-condensed">
     <thead>
       <tr>

--- a/promgen/templates/promgen/global_messages.html
+++ b/promgen/templates/promgen/global_messages.html
@@ -1,5 +1,5 @@
 {% for message in messages %}
-<div class="alert {% if message.tags %}alert-{{ message.tags }}{% endif %}" role="alert">
+<div class="alert {% if message.tags %}alert-{{ message.tags }}{% endif %}" role="alert" v-pre>
     <button type="button" class="close" data-dismiss="alert">
         <span aria-hidden="true">&times;</span>
     </button>

--- a/promgen/templates/promgen/graph.html
+++ b/promgen/templates/promgen/graph.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 
 {% block content %}
-<div class="panel">
+<div class="panel" v-pre>
   <div class="panel-body">
     <form action="{{shard.url}}/graph">
       <dl class="dl-horizontal">

--- a/promgen/templates/promgen/host_404.html
+++ b/promgen/templates/promgen/host_404.html
@@ -3,16 +3,16 @@
 {% block title %}No hosts found for {{ slug }}{% endblock %}
 
 {% block content %}
-<div class="page-header">
+<div class="page-header" v-pre>
   <h1>Host: {{ slug }}</h1>
 </div>
 
-<ol class="breadcrumb">
+<ol class="breadcrumb" v-pre>
   <li><a href="{% url 'service-list' %}">Home</a></li>
   <li class="active">{{ slug }}</li>
 </ol>
 
-<div class="alert alert-danger" role="alert">
+<div class="alert alert-danger" role="alert" v-pre>
 No hosts found for {{ slug }}
 </div>
 {% endblock %}

--- a/promgen/templates/promgen/host_block.html
+++ b/promgen/templates/promgen/host_block.html
@@ -1,4 +1,4 @@
-<div class="row">
+<div class="row" v-pre>
 
 {% for project in host.farm.project_set.all %}
 <div class="col-md-6">

--- a/promgen/templates/promgen/host_detail.html
+++ b/promgen/templates/promgen/host_detail.html
@@ -2,11 +2,11 @@
 {% load i18n %}
 {% block content %}
 
-<div class="page-header">
+<div class="page-header" v-pre>
   <h1>Host: {{ slug }}</h1>
 </div>
 
-<ol class="breadcrumb">
+<ol class="breadcrumb" v-pre>
   <li><a href="{% url 'service-list' %}">Home</a></li>
   <li class="active">{{ slug }}</li>
 </ol>
@@ -29,7 +29,7 @@
 
 <div class="row">
 
-<div class="col-sm-6"><div class="panel panel-primary">
+<div class="col-sm-6"><div class="panel panel-primary" v-pre>
   <div class="panel-heading">Farm</div>
   <table class="table">
     <tr>
@@ -43,7 +43,7 @@
   </table>
 </div></div>
 
-<div class="col-sm-6"><div class="panel panel-primary">
+<div class="col-sm-6"><div class="panel panel-primary" v-pre>
   <div class="panel-heading">Project</div>
   <table class="table">
     <tr>
@@ -57,7 +57,7 @@
   </table>
 </div></div>
 
-<div class="col-sm-6"><div class="panel panel-primary">
+<div class="col-sm-6"><div class="panel panel-primary" v-pre>
   <div class="panel-heading">Exporters</div>
   <table class="table">
     <tr>
@@ -79,7 +79,7 @@
   </table>
 </div></div>
 
-<div class="col-sm-6"><div class="panel panel-primary">
+<div class="col-sm-6"><div class="panel panel-primary" v-pre>
   <div class="panel-heading">Notifiers</div>
   <table class="table">
     <tr>
@@ -106,7 +106,7 @@
   <table class="table table-bordered table-condensed">
     {% include "promgen/rule_header.html" %}
     {% for service in service_list %}
-    <tr>
+    <tr v-pre>
       <td colspan="5">
         <h2>
           Rules from <a href="{{ service.grouper.get_absolute_url }}">{{ service.grouper }}</a>

--- a/promgen/templates/promgen/host_form.html
+++ b/promgen/templates/promgen/host_form.html
@@ -3,18 +3,18 @@
 
 {% block content %}
 
-<div class="page-header">
+<div class="page-header" v-pre>
   <h1>Farm: {{ farm.name }}</h1>
 </div>
 
-<ol class="breadcrumb">
+<ol class="breadcrumb" v-pre>
   <li><a href="{% url 'service-list' %}">Home</a></li>
   <li><a href="{% url 'service-detail' project.service.id %}">{{ project.service.name }}</a></li>
   <li><a href="{% url 'project-detail' project.id %}">{{ project.name }}</a></li>
   <li class="active">Add hosts to {{ farm.name }}</li>
 </ol>
 
-<form action="{% url 'hosts-add' farm.id %}" method="post">{% csrf_token %}
+<form action="{% url 'hosts-add' farm.id %}" method="post" v-pre>{% csrf_token %}
   <table>
     {{ form.as_table }}
   </table>

--- a/promgen/templates/promgen/host_list.html
+++ b/promgen/templates/promgen/host_list.html
@@ -20,7 +20,7 @@
         </tr>
       </thead>
 {% for name, hosts in host_groups.items %}
-<tr>
+<tr v-pre>
   <td><a href="{% url 'host-detail' name %}">{{ name }}</a></td>
   <td>
     <ul>

--- a/promgen/templates/promgen/import_form.html
+++ b/promgen/templates/promgen/import_form.html
@@ -14,7 +14,7 @@
 <div class="panel panel-default">
   <div class="panel-heading">Import Targets</div>
   <div class="panel-body">
-    <form action="" method="post" enctype="multipart/form-data">{% csrf_token %}
+    <form action="" method="post" enctype="multipart/form-data" v-pre>{% csrf_token %}
         {{ form.as_p }}
         <button class="btn btn-primary">Import Targets</button>
     </form>

--- a/promgen/templates/promgen/link_farm.html
+++ b/promgen/templates/promgen/link_farm.html
@@ -2,18 +2,18 @@
 
 {% block content %}
 
-<div class="page-header">
+<div class="page-header" v-pre>
   <h1>Project: {{ project.name }}</h1>
 </div>
 
-<ol class="breadcrumb">
+<ol class="breadcrumb" v-pre>
   <li><a href="{% url 'service-list' %}">Home</a></li>
   <li><a href="{% url 'service-detail' project.service.id %}">{{ project.service.name }}</a></li>
   <li><a href="{% url 'project-detail' project.id %}">{{ project.name }}</a></li>
   <li class="active">Link Farm {{ source }}</li>
 </ol>
 
-<div class="panel panel-default">
+<div class="panel panel-default" v-pre>
   <div class="panel-heading">
     <input class="form-control" data-filter="div.auto-grid div" placeholder="Type to filter">
   </div>

--- a/promgen/templates/promgen/navbar.html
+++ b/promgen/templates/promgen/navbar.html
@@ -56,7 +56,7 @@
                 <span v-text="activeSilences.length" class="badge"></span>
             </a>
 
-            <ul class="nav navbar-nav navbar-right">
+            <ul class="nav navbar-nav navbar-right" v-pre>
                 <li class="dropdown">
                     <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
                         {{user.username}} <span class="caret"></span>

--- a/promgen/templates/promgen/notifier_form.html
+++ b/promgen/templates/promgen/notifier_form.html
@@ -2,13 +2,13 @@
 {% load promgen %}
 {% block content %}
 
-<div class="page-header">
+<div class="page-header" v-pre>
   <h1>{{object|klass}}: {{object.name}}</h1>
 </div>
 
 {% breadcrumb object 'Register Notifier' %}
 
-<div class="row">
+<div class="row" v-pre>
   <div class="col-md-3">
     <ul class="nav nav-pills nav-stacked" role="tablist">
       {% for k, v in view.model.driver_set|dictsort:0 %}

--- a/promgen/templates/promgen/pagination.html
+++ b/promgen/templates/promgen/pagination.html
@@ -1,5 +1,5 @@
 {% load promgen %}
-<nav aria-label="Page navigation">
+<nav aria-label="Page navigation" v-pre>
     {% if page_obj.has_other_pages %}
     <ul class="pagination">
         {% if page_obj.has_previous %}

--- a/promgen/templates/promgen/pagination_short.html
+++ b/promgen/templates/promgen/pagination_short.html
@@ -1,5 +1,5 @@
 {% load promgen %}
-<nav aria-label="Page navigation">
+<nav aria-label="Page navigation" v-pre>
     {% if page_obj.has_other_pages %}
     <ul class="pagination">
         {% if page_obj.has_previous %}

--- a/promgen/templates/promgen/profile.html
+++ b/promgen/templates/promgen/profile.html
@@ -3,11 +3,11 @@
 {% block content %}
 
 
-<div class="page-header">
+<div class="page-header" v-pre>
   <h1>{{user.username}} ({{user.email}})</h1>
 </div>
 
-<div class="panel panel-primary">
+<div class="panel panel-primary" v-pre>
   <div class="panel-heading">Subscriptions</div>
   <table class="table">
     <tr>
@@ -50,7 +50,7 @@
 <div class="panel panel-primary">
   <div class="panel-heading">Notifications</div>
   {% include "promgen/notifier_block.html" with object=notifiers show_edit=1 %}
-  <div class="panel-body">
+  <div class="panel-body" v-pre>
     <div class="row">
       <div class="col-md-3">
         <ul class="nav nav-pills nav-stacked" role="tablist">
@@ -89,7 +89,7 @@
 </div>
 
 {% if user.is_staff %}
-<div class="panel panel-warning">
+<div class="panel panel-warning" v-pre>
   <div class="panel-heading">Debug</div>
   <table class="table">
     <tr>

--- a/promgen/templates/promgen/project_detail.html
+++ b/promgen/templates/promgen/project_detail.html
@@ -8,7 +8,7 @@ Promgen / Project / {{ project.name }}
 
 {% block content %}
 
-<div class="page-header">
+<div class="page-header" v-pre>
   <h1>
     Project: {{ project.name }}
     {% if project.owner %}

--- a/promgen/templates/promgen/project_detail_configuration.html
+++ b/promgen/templates/promgen/project_detail_configuration.html
@@ -58,7 +58,7 @@
 
   {% endif %}
 
-  <div class="panel-footer">
+  <div class="panel-footer" v-pre>
     Datasource: <a href="{{project.shard.get_absolute_url}}">{{project.shard.name}}</a>
     ( <a href="{{project.shard.url}}">{{project.shard.url}}</a> )
   </div>

--- a/promgen/templates/promgen/project_detail_exporters.html
+++ b/promgen/templates/promgen/project_detail_exporters.html
@@ -11,9 +11,9 @@
     </tr>
   {% for exporter in project.exporter_set.all %}
     <tr {% if not exporter.enabled %}class="promgen-disabled"{% endif %}>
-      <td>{{ exporter.job }}</td>
-      <td>{{ exporter.scheme }}:{{ exporter.port }}</td>
-      <td>{{ exporter.path | default:"/metrics" }}</td>
+      <td v-pre>{{ exporter.job }}</td>
+      <td v-pre>{{ exporter.scheme }}:{{ exporter.port }}</td>
+      <td v-pre>{{ exporter.path | default:"/metrics" }}</td>
       <td style="white-space: nowrap">
         <input
           type="checkbox"

--- a/promgen/templates/promgen/project_detail_hosts.html
+++ b/promgen/templates/promgen/project_detail_hosts.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 <div class="panel panel-primary">
-  <div class="panel-heading">Hosts from {{ project.farm.name }} ({{ project.farm.source }})</div>
+  <div class="panel-heading" v-pre>Hosts from {{ project.farm.name }} ({{ project.farm.source }})</div>
   <table class="table">
     <tr>
       <th>&nbsp;</th>
@@ -13,7 +13,7 @@
   {% for host in project.farm.host_set.all %}
     <tr>
       <td><input type="checkbox" value="{{ host.name }}:[0-9]*" v-model="selectedHosts"></td>
-      <td><a href="{% url 'host-detail' host.name %}">{{ host.name }}</a></td>
+      <td v-pre><a href="{% url 'host-detail' host.name %}">{{ host.name }}</a></td>
       <td>
         <a
           @click="setSilenceDataset"
@@ -83,7 +83,7 @@
 {% else %}
     <a href="{% url 'farm-new' project.id %}" class="btn btn-primary">{% trans "Register Farm" %}</a>
 {% for name, source in sources %}
-    <a href="{% url 'farm-link' project.id name %}" class="btn btn-default">
+    <a href="{% url 'farm-link' project.id name %}" class="btn btn-default" v-pre>
       {% if source.remote %}
         <span class="glyphicon glyphicon-cloud-download" aria-hidden="true"></span>
       {% endif %}

--- a/promgen/templates/promgen/project_detail_notifiers.html
+++ b/promgen/templates/promgen/project_detail_notifiers.html
@@ -2,7 +2,7 @@
 
 {% if project.service.notifiers.count %}
 <div class="panel panel-default">
-  <div class="panel-heading">
+  <div class="panel-heading" v-pre>
     <a class="btn btn-default btn-sm" role="button" data-toggle="collapse" href="#show-service-senders" aria-expanded="false" aria-controls="collapseExample">
       Service Notifiers ({{project.service.notifiers.count}})
     </a>
@@ -15,7 +15,7 @@
 <div class="panel panel-primary">
   <div class="panel-heading">Project Notifiers</div>
   {% include "promgen/notifier_block.html" with object=project show_edit=1 %}
-  <div class="panel-footer">
+  <div class="panel-footer" v-pre>
     <a href="{% url 'project-notifier' project.id %}" class="btn btn-primary">{% trans "Register Notifier" %}</a>
     <form action="{% url 'project-notifier' project.id %}" style="display:inline" method="post">{% csrf_token %}
       <input type="hidden" name="sender" value="promgen.notification.user">

--- a/promgen/templates/promgen/project_detail_rules.html
+++ b/promgen/templates/promgen/project_detail_rules.html
@@ -1,7 +1,7 @@
 {% load i18n %}
 
 <div class="panel panel-primary">
-  <div class="panel-heading">
+  <div class="panel-heading" v-pre>
     Rules for {{ project.name }}
   </div>
   <table class="table table-bordered table-condensed">

--- a/promgen/templates/promgen/project_detail_urls.html
+++ b/promgen/templates/promgen/project_detail_urls.html
@@ -10,8 +10,8 @@
     </tr>
     {% for url in project.url_set.all %}
     <tr>
-      <td>{{ url.url }}</td>
-      <td title="{{ url.probe.description }}">{{ url.probe.module }}</td>
+      <td v-pre>{{ url.url }}</td>
+      <td title="{{ url.probe.description }}" v-pre>{{ url.probe.module }}</td>
       <td>
         <a @click="setSilenceDataset"
           class="btn btn-warning btn-xs"
@@ -32,7 +32,7 @@
   </table>
   <form method="post" action="{% url 'url-new' project.id %}" style="display: inline">
     {% csrf_token %}
-    <table class="table table-condensed">
+    <table class="table table-condensed" v-pre>
       {{url_form.as_table}}
     </table>
     <div class="panel-footer">

--- a/promgen/templates/promgen/project_form.html
+++ b/promgen/templates/promgen/project_form.html
@@ -3,7 +3,7 @@
 {% block content %}
 
 {% if project %}
-<div class="page-header">
+<div class="page-header" v-pre>
   <h1>Project: {{ project.name }}</h1>
 </div>
 
@@ -80,8 +80,8 @@
       </tr>
       {% for shard in shard_list|dictsort:'name' %}
       <tr {% if shard.enabled is False %}class="text-muted" title="Datasource disabled for new registrations" {% endif %}>
-        <th>{{shard.name}}</th>
-        <th>{{shard.url|urlize}}</th>
+        <th v-pre>{{shard.name}}</th>
+        <th v-pre>{{shard.url|urlize}}</th>
         <td>
           <input type="radio" name="shard" value="{{shard.id}}" {% if shard.id == form.shard.value %}checked{% elif shard.enabled is False %}disabled{% endif %}>
         </td>

--- a/promgen/templates/promgen/project_row.html
+++ b/promgen/templates/promgen/project_row.html
@@ -1,9 +1,9 @@
 {% load i18n %}
 <tr>
-    <td><a href="{{project.get_absolute_url}}">{{ project.name }}</a></td>
+    <td v-pre><a href="{{project.get_absolute_url}}">{{ project.name }}</a></td>
 
     <td>
-        <table style="width: 100%">
+        <table style="width: 100%" v-pre>
             {% for exporter in project.exporter_set.all %}
             <tr {% if not exporter.enabled %}class="promgen-disabled" {% endif %}>
                 <td>{{ exporter.job }}</td>
@@ -21,7 +21,7 @@
     </td>
 
     <td>
-        <table style="width: 100%">
+        <table style="width: 100%" v-pre>
             {% for notifier in project.notifiers.all %}
             <tr>
                 <td title="Added by: {{notifier.owner}}">{{ notifier.sender }}</td>

--- a/promgen/templates/promgen/rule_block.html
+++ b/promgen/templates/promgen/rule_block.html
@@ -1,7 +1,7 @@
 {% load i18n %}
 
 {% for rule in rule_list %}
-<tr class="{% if not rule.enabled %}promgen-disabled{% endif %} {% if collapse %}active collapse {{ collapse }}{{overwrite_id}}{% endif %}">
+<tr class="{% if not rule.enabled %}promgen-disabled{% endif %} {% if collapse %}active collapse {{ collapse }}{{overwrite_id}}{% endif %}" v-pre>
   <td>
     <a title="{{rule.description}}" data-toggle="tooltip" data-placement="right" href="{% url 'rule-detail' rule.id %}">{{ rule.name }}</a>
     {% if rule.parent %}
@@ -48,7 +48,7 @@
 </tr>
 {% empty %}
 {% if show_empty %}
-<tr>
+<tr v-pre>
   <td colspan=5>No rules found for {{show_empty}}</td>
 </tr>
 {% endif %}

--- a/promgen/templates/promgen/rule_detail.html
+++ b/promgen/templates/promgen/rule_detail.html
@@ -8,7 +8,7 @@ Promgen / Rule / {{ rule.name }}
 {% endblock %}
 
 {% block content %}
-<div class="page-header">
+<div class="page-header" v-pre>
     <h1>Rule: {{ rule.name }}</h1>
 </div>
 
@@ -25,7 +25,7 @@ Promgen / Rule / {{ rule.name }}
     </table>
 </div>
 
-<div class="panel panel-primary">
+<div class="panel panel-primary" v-pre>
     <div class="panel-heading">{{rule.name}}</div>
     <div class="panel-body">
 {% if rule.description %}
@@ -43,7 +43,7 @@ Promgen / Rule / {{ rule.name }}
 </div>
 
 {% if rule.parent %}
-<div class="panel panel-default">
+<div class="panel panel-default" v-pre>
     <div class="panel-heading">Parent</div>
     <table class="table">
         <tr>
@@ -61,7 +61,7 @@ Promgen / Rule / {{ rule.name }}
 {% endif %}
 
 {% if rule.overrides.count %}
-<div class="panel panel-default">
+<div class="panel panel-default" v-pre>
     <div class="panel-heading">Child Rules</div>
     <table class="table">
         <tr>

--- a/promgen/templates/promgen/rule_form_block.html
+++ b/promgen/templates/promgen/rule_form_block.html
@@ -1,5 +1,5 @@
 <div class="panel panel-primary">
-  <div class="panel-heading">{{ rule.name|default:"New Rule" }}</div>
+  <div class="panel-heading" v-pre>{{ rule.name|default:"New Rule" }}</div>
   <div class="panel-body">
     {% include 'promgen/error_block.html' with warning=form.name.errors only %}
     {{ form.name.label_tag }}
@@ -52,7 +52,7 @@
     {% include 'promgen/error_block.html' with errors=form.clause.errors only %}
     {{ form.clause.label_tag }}
     {{ form.clause }}
-    <p>
+    <p v-pre>
       Example Query:
       <code
         data-href="{% url 'rule-test' rule.id %}"
@@ -91,7 +91,7 @@
 
     {% if rule.parent %}
     {% if macro not in rule.parent.clause %}
-    <div class="alert alert-warning" role="alert">
+    <div class="alert alert-warning" role="alert" v-pre>
       <span class="glyphicon glyphicon-alert" aria-hidden="true"></span>
       <span class="sr-only">Warning:</span>
       Missing <strong>{{ macro }}</strong> macro in parent rule. Please reffer to Promgen's documentation regarding

--- a/promgen/templates/promgen/rule_import.html
+++ b/promgen/templates/promgen/rule_import.html
@@ -14,7 +14,7 @@
 <div class="panel panel-default">
   <div class="panel-heading">Import Rules</div>
   <div class="panel-body">
-    <form action="{% url 'rule-import' %}" method="post" enctype="multipart/form-data">{% csrf_token %}
+    <form action="{% url 'rule-import' %}" method="post" enctype="multipart/form-data" v-pre>{% csrf_token %}
       {{ form.as_p }}
       <button class="btn btn-primary">Import Rules</button>
     </form>

--- a/promgen/templates/promgen/rule_list.html
+++ b/promgen/templates/promgen/rule_list.html
@@ -16,7 +16,7 @@
 
 {% for group in grouped_rule_list %}
 <div class="panel panel-default">
-  <div class="panel-heading">
+  <div class="panel-heading" v-pre>
     <a href="{{ group.grouper.get_absolute_url }}">{{ group.grouper }}</a>
     <a href="{% url 'rule-new' group.grouper|klass|lower group.grouper.id %}" class="btn btn-primary btn-xs pull-right">{% trans "Register Rule" %}</a>
   </div>

--- a/promgen/templates/promgen/rule_register.html
+++ b/promgen/templates/promgen/rule_register.html
@@ -10,7 +10,7 @@ Promgen / Rule / New
 {% breadcrumb rule 'New Rule' %}
 
 {% if form.non_field_errors  %}
-<div class="panel panel-danger">
+<div class="panel panel-danger" v-pre>
   <div class="panel-heading">Errors</div>
     {% for error in form.non_field_errors %}
       <div class="panel-body">{{ error|linebreaks }}</div>

--- a/promgen/templates/promgen/rule_update.html
+++ b/promgen/templates/promgen/rule_update.html
@@ -8,7 +8,7 @@ Promgen / Rule / {{ rule.name }}
 {% endblock %}
 
 {% block content %}
-<div class="page-header">
+<div class="page-header" v-pre>
   <h1>Rule: {{ rule.name }}</h1>
 </div>
 
@@ -69,7 +69,7 @@ Promgen / Rule / {{ rule.name }}
   </div><!-- end row -->
 
   {% if rule.overrides.count %}
-  <div class="panel panel-default">
+  <div class="panel panel-default" v-pre>
     <div class="panel-heading">
       Child Rules
     </div>

--- a/promgen/templates/promgen/search.html
+++ b/promgen/templates/promgen/search.html
@@ -12,7 +12,7 @@
 </ol>
 
 {% if service_list %}
-<div class="panel panel-default">
+<div class="panel panel-default" v-pre>
   <div class="panel-heading">Services</div>
   <table class="table table-bordered table-condensed">
     <tr>
@@ -61,7 +61,7 @@
 {% endif %}
 
 {% if farm_list %}
-<div class="panel panel-default">
+<div class="panel panel-default" v-pre>
   <div class="panel-heading">Farms</div>
   <table class="table table-bordered table-condensed">
     <tr>
@@ -100,7 +100,7 @@
 {% endif %}
 
 {% if host_list %}
-<div class="panel panel-default">
+<div class="panel panel-default" v-pre>
   <div class="panel-heading">Hosts</div>
   <table class="table">
     {% for host in host_list %}

--- a/promgen/templates/promgen/sender_form.html
+++ b/promgen/templates/promgen/sender_form.html
@@ -4,7 +4,7 @@
 {% block content %}
 
 
-<div class="page-header">
+<div class="page-header" v-pre>
   <h1>{{object|klass}}: {{object.name}}</h1>
 </div>
 

--- a/promgen/templates/promgen/sender_row.html
+++ b/promgen/templates/promgen/sender_row.html
@@ -1,14 +1,14 @@
 {% load i18n %}
 <tr {% if not notifier.enabled %}class="promgen-disabled"{% endif %}>
-    <td class="col-xs-2" title="Added by: {{notifier.owner}}">{{ notifier.sender }}</td>
-    <td class="col-xs-5" style="word-break: break-all;" >{{ notifier.show_value }}</td>
+    <td class="col-xs-2" title="Added by: {{notifier.owner}}" v-pre>{{ notifier.sender }}</td>
+    <td class="col-xs-5" style="word-break: break-all;" v-pre>{{ notifier.show_value }}</td>
     <td class="col-xs-2">
         {% for f in notifier.filter_set.all %}
         <form method="post" action="{% url 'notifier-edit' notifier.id %}" onsubmit="return confirm('Delete this filter?')" style="display: inline">
             {% csrf_token %}
             <input name="next" type="hidden" value="{{ request.get_full_path }}" />
             <input name="filter.pk" value="{{f.id}}" type="hidden" />
-            <button class="label label-primary" style="display: inline-block;">
+            <button class="label label-primary" style="display: inline-block;" v-pre>
                 {{f.name}}:{{f.value}}
                 <span class="glyphicon glyphicon-remove" aria-hidden="true"></span>
             </button>

--- a/promgen/templates/promgen/service_block.html
+++ b/promgen/templates/promgen/service_block.html
@@ -44,7 +44,7 @@
         </ul>
       </div>
 
-      <form action="{% url 'service-notifier' service.id %}" style="display:inline" method="post">{% csrf_token %}
+      <form action="{% url 'service-notifier' service.id %}" style="display:inline" method="post" v-pre>{% csrf_token %}
         <input type="hidden" name="sender" value="promgen.notification.user">
         <input type="hidden" name="value" value="{{request.user.username}}" />
         <button class="btn btn-primary btn-sm">{% trans "Subscribe to Notifications" %}</button>

--- a/promgen/templates/promgen/service_block_projects.html
+++ b/promgen/templates/promgen/service_block_projects.html
@@ -4,7 +4,7 @@
 
 {% for shard, shard_projects in project_shard_list %}
 <div class="panel panel-default">
-    <div class="panel-heading">
+    <div class="panel-heading" v-pre>
         Datasource
         <a href="{{shard.get_absolute_url}}">{{shard.name}}</a>
         ( <a href="{{shard.url}}">{{shard.url}}</a> )

--- a/promgen/templates/promgen/service_detail.html
+++ b/promgen/templates/promgen/service_detail.html
@@ -8,7 +8,7 @@ Promgen / Service / {{ service.name }}
 
 {% block content %}
 
-<div class="page-header">
+<div class="page-header" v-pre>
   <h1>Service: {{ service.name }}</h1>
   {% if service.owner %}
   <p>{% trans 'Contact' %}: {{service.owner.username}}</p>

--- a/promgen/templates/promgen/service_form.html
+++ b/promgen/templates/promgen/service_form.html
@@ -2,7 +2,7 @@
 {% load promgen %}
 {% block content %}
 
-<div class="page-header">
+<div class="page-header" v-pre>
   <h1>{{ view.button_label }}</h1>
 </div>
 
@@ -14,7 +14,7 @@
 </div>
 {% endif %}
 
-<div class="panel panel-default">
+<div class="panel panel-default" v-pre>
   <form action="" method="post">{% csrf_token %}
     <table class="table">
       {{ form.as_table }}

--- a/promgen/templates/promgen/service_header.html
+++ b/promgen/templates/promgen/service_header.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 
-<h2>
+<h2 v-pre>
     <a href="{% url 'service-detail' service.id %}">{{ service.name }}</a>
     {% if service.owner %}
     <small class="pull-right">{% trans 'Contact' %}: {{service.owner.username}}</small>

--- a/promgen/templates/promgen/shard_detail.html
+++ b/promgen/templates/promgen/shard_detail.html
@@ -8,7 +8,7 @@ Promgen / Datasource / {{ shard.name }}
 
 {% block content %}
 
-<div class="page-header">
+<div class="page-header" v-pre>
   <h1>Datasource: {{ shard.name }}</h1>
   <a href="{{shard.url}}">{{shard.url}}</a>
 </div>
@@ -21,7 +21,7 @@ Promgen / Datasource / {{ shard.name }}
 <table class="table table-bordered table-condensed">
   {% for service, project_list in service_list|dictsort:"grouper.name" %}
 
-  <tr>
+  <tr v-pre>
     <th colspan="4">
       <h2>
         <a href="{% url 'service-detail' service.id %}">{{ service.name }}</a>

--- a/promgen/templates/promgen/shard_list.html
+++ b/promgen/templates/promgen/shard_list.html
@@ -13,8 +13,8 @@
 <div class="service-grid">
   {% for shard in shard_list|dictsortreversed:"num_projects" %}
   <div>
-    <h2><a href="{% url 'datasource-detail' shard.id %}">{{ shard.name }}</a></h2>
-    <a href="{{shard.url}}">{{shard.url}}</a>
+    <h2><a href="{% url 'datasource-detail' shard.id %}" v-pre>{{ shard.name }}</a></h2>
+    <a href="{{shard.url}}" v-pre>{{shard.url}}</a>
     <hr>
 
     {% include 'promgen/shard_header.html' %}
@@ -24,7 +24,7 @@
       {% for service, project_list in service_list|dictsort:"grouper.name" %}
       <tr>
         <td>
-          <a href="{{service.get_absolute_url}}">{{ service.name }}</a>
+          <a href="{{service.get_absolute_url}}" v-pre>{{ service.name }}</a>
         </td>
       </tr>
       {% endfor %}

--- a/promgen/templates/promgen/url_form.html
+++ b/promgen/templates/promgen/url_form.html
@@ -3,17 +3,17 @@
 {% block content %}
 
 <div class="page-header">
-  <h1>Project: {{ project.name }}</h1>
+  <h1 v-pre>Project: {{ project.name }}</h1>
 </div>
 
-<ol class="breadcrumb">
+<ol class="breadcrumb" v-pre>
   <li><a href="{% url 'service-list' %}">Home</a></li>
   <li><a href="{% url 'service-detail' project.service.id %}">{{ project.service.name }}</a></li>
   <li><a href="{% url 'project-detail' project.id %}">{{ project.name }}</a></li>
   <li class="active">Add URL to {{ farm.name }}</li>
 </ol>
 
-<form action="{% url 'url-new' project.id %}" method="post">{% csrf_token %}
+<form action="{% url 'url-new' project.id %}" method="post" v-pre>{% csrf_token %}
   <table>
     {{ form.as_table }}
   </table>

--- a/promgen/templates/promgen/url_list.html
+++ b/promgen/templates/promgen/url_list.html
@@ -12,7 +12,7 @@
 
 {% breadcrumb label='All URLs' %}
 
-<table class="table table-bordered table-condensed">
+<table class="table table-bordered table-condensed" v-pre>
   <tr>
     <th>URL</th>
     <th colspan="3">Module</th>

--- a/promgen/templates/registration/login.html
+++ b/promgen/templates/registration/login.html
@@ -5,7 +5,7 @@
 <h2 class="form-signin-heading">OAuth Login</h2>
 <div class="panel panel-default">
 {% for backend in backends.not_associated %}
-    <form action="{% url 'social:begin' backend %}">
+    <form action="{% url 'social:begin' backend %}" v-pre>
         <input type="hidden" name="next" value="{{ next }}" />
         <button class="btn btn-block btn-default" type="submit">Sign in with {{backend}}</button>
     </form>
@@ -27,7 +27,7 @@
         <p class="alert alert-warning" role="alert">Please login to see this page.</p>
         {% endif %}
     {% endif %}
-    <form method="post" action="{% url 'login' %}">
+    <form method="post" action="{% url 'login' %}" v-pre>
         {% csrf_token %}
         <input type="hidden" name="next" value="{{ next }}" />
         <p><input type="text" name="{{ form.username.name }}" class="form-control" placeholder="{{ form.username.label }}" value="" required autofocus></p>


### PR DESCRIPTION
When rendering the front end code with Jinja on the server side, the resulting rendered code may include Vue delimiters that will be interpreted by Vue on the client side.

To prevent that, we have added v-pre to some elements in those places where we think we can have issues.