### PR TITLE
global_messages: Move v-pre to a more specific place

### DIFF
--- a/promgen/templates/promgen/global_messages.html
+++ b/promgen/templates/promgen/global_messages.html
@@ -1,9 +1,9 @@
 {% for message in messages %}
-<div class="alert {% if message.tags %}alert-{{ message.tags }}{% endif %}" role="alert" v-pre>
+<div class="alert {% if message.tags %}alert-{{ message.tags }}{% endif %}" role="alert">
     <button type="button" class="close" data-dismiss="alert">
         <span aria-hidden="true">&times;</span>
     </button>
-    {{ message }}
+    <span v-pre>{{ message }}</span>
 </div>
 {% endfor %}
 


### PR DESCRIPTION
It seems that v-pre was being ignored, so let's place it closer to the stuff we want to ignore.