### PR TITLE
Fix search: Be more specific with v-pre

### DIFF
--- a/promgen/templates/promgen/project_row.html
+++ b/promgen/templates/promgen/project_row.html
@@ -1,14 +1,14 @@
 {% load i18n %}
 <tr>
-    <td v-pre><a href="{{project.get_absolute_url}}">{{ project.name }}</a></td>
+    <td><a href="{{project.get_absolute_url}}" v-pre>{{ project.name }}</a></td>
 
     <td>
-        <table style="width: 100%" v-pre>
+        <table style="width: 100%">
             {% for exporter in project.exporter_set.all %}
             <tr {% if not exporter.enabled %}class="promgen-disabled" {% endif %}>
-                <td>{{ exporter.job }}</td>
-                <td>{{ exporter.port }}</td>
-                <td>{{ exporter.path }}</td>
+                <td v-pre>{{ exporter.job }}</td>
+                <td v-pre>{{ exporter.port }}</td>
+                <td v-pre>{{ exporter.path }}</td>
             </tr>
             {% empty %}
             <tr>
@@ -21,11 +21,11 @@
     </td>
 
     <td>
-        <table style="width: 100%" v-pre>
+        <table style="width: 100%">
             {% for notifier in project.notifiers.all %}
             <tr>
-                <td title="Added by: {{notifier.owner}}">{{ notifier.sender }}</td>
-                <td>{{ notifier.show_value }}</td>
+                <td title="Added by: {{notifier.owner}}" v-pre>{{ notifier.sender }}</td>
+                <td v-pre>{{ notifier.show_value }}</td>
             </tr>
             {% empty %}
             <tr>

--- a/promgen/templates/promgen/rule_block.html
+++ b/promgen/templates/promgen/rule_block.html
@@ -1,9 +1,9 @@
 {% load i18n %}
 
 {% for rule in rule_list %}
-<tr class="{% if not rule.enabled %}promgen-disabled{% endif %} {% if collapse %}active collapse {{ collapse }}{{overwrite_id}}{% endif %}" v-pre>
+<tr class="{% if not rule.enabled %}promgen-disabled{% endif %} {% if collapse %}active collapse {{ collapse }}{{overwrite_id}}{% endif %}">
   <td>
-    <a title="{{rule.description}}" data-toggle="tooltip" data-placement="right" href="{% url 'rule-detail' rule.id %}">{{ rule.name }}</a>
+    <a title="{{rule.description}}" data-toggle="tooltip" data-placement="right" href="{% url 'rule-detail' rule.id %}" v-pre>{{ rule.name }}</a>
     {% if rule.parent %}
     <a class="pull-right" title="{% trans "View Parent" %}" href="{% url 'rule-detail' rule.parent.id %}">
       <span class="glyphicon glyphicon-upload"></span>
@@ -11,13 +11,13 @@
     {% endif %}
     <ul>
       {% for k,v in rule.labels.items|dictsort:0 %}
-      <li class="label label-primary">{{k}}:{{v}}</li>
+      <li class="label label-primary" v-pre>{{k}}:{{v}}</li>
       {% endfor %}
     </ul>
   </td>
-  <td class="promgen-clause">{{ rule.clause }}</td>
+  <td class="promgen-clause" v-pre>{{ rule.clause }}</td>
 
-  <td>{{ rule.duration }}</td>
+  <td v-pre>{{ rule.duration }}</td>
 
   {% if toggle %}
   <td style="white-space: nowrap">
@@ -48,8 +48,8 @@
 </tr>
 {% empty %}
 {% if show_empty %}
-<tr v-pre>
-  <td colspan=5>No rules found for {{show_empty}}</td>
+<tr>
+  <td colspan=5 v-pre>No rules found for {{show_empty}}</td>
 </tr>
 {% endif %}
 {% endfor %}

--- a/promgen/templates/promgen/search.html
+++ b/promgen/templates/promgen/search.html
@@ -12,7 +12,7 @@
 </ol>
 
 {% if service_list %}
-<div class="panel panel-default" v-pre>
+<div class="panel panel-default">
   <div class="panel-heading">Services</div>
   <table class="table table-bordered table-condensed">
     <tr>
@@ -22,18 +22,18 @@
     </tr>
     {% for service in service_list %}
     <tr>
-      <td><a href="{% url 'service-detail' service.id %}">{{ service.name }}</a></td>
+      <td><a href="{% url 'service-detail' service.id %}" v-pre>{{ service.name }}</a></td>
       <td>
         <ul class="list-unstyled">
         {% for project in service.project_set.all %}
-          <li><a href="{% url 'project-detail' project.id %}">{{ project.name }}</a></li>
+          <li><a href="{% url 'project-detail' project.id %}" v-pre>{{ project.name }}</a></li>
         {% endfor %}
         </ul>
       </td>
       <td>
         <ul class="list-unstyled">
         {% for rule in service.rule_set.all %}
-          <li><a href="{% url 'rule-detail' rule.id %}">{{ rule.name }}</a></li>
+          <li><a href="{% url 'rule-detail' rule.id %}" v-pre>{{ rule.name }}</a></li>
         {% endfor %}
         </ul>
       </td>
@@ -61,7 +61,7 @@
 {% endif %}
 
 {% if farm_list %}
-<div class="panel panel-default" v-pre>
+<div class="panel panel-default">
   <div class="panel-heading">Farms</div>
   <table class="table table-bordered table-condensed">
     <tr>
@@ -71,11 +71,11 @@
     </tr>
     {% for farm in farm_list %}
     <tr>
-      <td><a href="{% url 'farm-detail' farm.id %}">{{ farm.name }}</a></td>
+      <td><a href="{% url 'farm-detail' farm.id %}" v-pre>{{ farm.name }}</a></td>
       <td>
         <ul class="list-unstyled">
 {% for project in farm.project_set.all %}
-          <li><a href="{% url 'project-detail' project.id %}">{{ project.name }}</a></li>
+          <li><a href="{% url 'project-detail' project.id %}" v-pre>{{ project.name }}</a></li>
 {% endfor %}
         </ul>
       </td>
@@ -83,7 +83,7 @@
         <ul class="list-unstyled">
 {% for host in farm.host_set.all %}
           <li>
-            <a href="{% url 'host-detail' host.name %}">{{ host.name }}</a>
+            <a href="{% url 'host-detail' host.name %}" v-pre>{{ host.name }}</a>
             <a
             @click="setSilenceDataset"
             class="btn btn-warning btn-xs"
@@ -100,12 +100,12 @@
 {% endif %}
 
 {% if host_list %}
-<div class="panel panel-default" v-pre>
+<div class="panel panel-default">
   <div class="panel-heading">Hosts</div>
   <table class="table">
     {% for host in host_list %}
       <tr>
-        <td><a href="{% url 'host-detail' host.name %}">{{ host.name }}</a></td>
+        <td><a href="{% url 'host-detail' host.name %}" v-pre>{{ host.name }}</a></td>
         <td><a
           @click="setSilenceDataset"
           class="btn btn-warning btn-xs"


### PR DESCRIPTION
By putting v-pre in parent elements in order to avoid putting more v-pre elements on some of its children, we have broken the search results.

Let's avoid doing this and instance put v-pre on the elements that need them.