### PR TITLE
Upgrade Celery

### DIFF
--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --no-emit-index-url --output-file=docker/requirements.txt docker/requirements.in pyproject.toml
 #
-amqp==2.6.1
+amqp==5.2.0
     # via kombu
 asgiref==3.7.2
     # via django
@@ -14,7 +14,7 @@ atomicwrites==1.4.1
     # via promgen (pyproject.toml)
 billiard==3.6.4.0
     # via celery
-celery[redis]==4.3.0
+celery[redis]==5.2.7
     # via
     #   -r docker/requirements.in
     #   promgen (pyproject.toml)
@@ -26,6 +26,18 @@ cffi==1.15.1
     # via cryptography
 charset-normalizer==3.2.0
     # via requests
+click==8.1.7
+    # via
+    #   celery
+    #   click-didyoumean
+    #   click-plugins
+    #   click-repl
+click-didyoumean==0.3.1
+    # via celery
+click-plugins==1.1.1
+    # via celery
+click-repl==0.3.0
+    # via celery
 cryptography==42.0.5
     # via social-auth-core
 defusedxml==0.7.1
@@ -48,7 +60,7 @@ gunicorn==22.0.0
     # via -r docker/requirements.in
 idna==3.7
     # via requests
-kombu==4.6.11
+kombu==5.3.7
     # via
     #   celery
     #   promgen (pyproject.toml)
@@ -60,6 +72,8 @@ packaging==23.1
     # via gunicorn
 prometheus-client==0.17.1
     # via promgen (pyproject.toml)
+prompt-toolkit==3.0.43
+    # via click-repl
 pycparser==2.21
     # via cffi
 pyjwt==2.8.0
@@ -94,14 +108,19 @@ social-auth-core==4.5.4
 sqlparse==0.5.0
     # via django
 typing-extensions==4.7.1
-    # via asgiref
+    # via
+    #   asgiref
+    #   kombu
 urllib3==2.2.0
     # via
     #   requests
     #   sentry-sdk
-vine==1.3.0
+vine==5.1.0
     # via
     #   amqp
     #   celery
+    #   kombu
+wcwidth==0.2.13
+    # via prompt-toolkit
 whitenoise==6.5.0
     # via -r docker/requirements.in

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ requires-python = ">=3.9"
 dependencies = [
     "Django~=4.2",
     "atomicwrites",
-    "celery==4.3.0",
+    "celery",
     "django-environ",
     "django-filter",
     "djangorestframework",


### PR DESCRIPTION
Though the upgraded list of dependencies required by celery are unfortunate, it's better to upgrade to a newer version for security reasons. Since we're not doing anything particularly fancy with Celery, it doesn't look like any code changes are required