### PR TITLE
Fix promql-query Vue component

### DIFF
--- a/promgen/static/js/promgen.vue.js
+++ b/promgen/static/js/promgen.vue.js
@@ -189,6 +189,7 @@ app.component("promql-query", {
     data: function () {
         return {
             count: 0,
+            ready: false,
         };
     },
     mixins: [mixins],
@@ -206,19 +207,12 @@ app.component("promql-query", {
     },
     template: '#promql-query-template',
     mounted() {
-        var this_ = this;
         var url = new URL(this.href);
         url.search = new URLSearchParams({ query: this.query });
         fetch(url)
             .then(response => response.json())
-            .then(result => Number.parseInt(result.data.result[0].value[1]))
-            .then(result => {
-                this_.count = result;
-                this_.$el.style.display = "inline";
-            })
-            .catch(error => {
-                this_.$el.style.display = "inline";
-            });
+            .then(result => this.count = Number.parseInt(result.data.result[0].value[1]))
+            .finally(() => this.ready = true);
     },
 });
 

--- a/promgen/templates/promgen/vue/promql_query.html
+++ b/promgen/templates/promgen/vue/promql_query.html
@@ -1,3 +1,3 @@
-<span style="display: none" :title="percent(load)" :class="classes">
-  [[ localize(count) ]] <slot></slot>
+<span v-show="ready" :title="percent(load)" :class="classes">
+  <slot></slot> [[ localize(count) ]]
 </span>


### PR DESCRIPTION
This component had some issues that prevented it to render properly.

First, the unnecessary usage of 'this_ = this'. In a Vue component, 'this' always refers to the component itself.

Second, the unreliable way to change the display CSS property by accessing 'this_.$el.style.display'. In Vue, we can do conditional rendering using the v-show directive. We have defined a new 'ready' variable that becomes 'true' when the component is ready to be rendered, and use v-show to toggle the visibility of the component based on the value of that variable.

Third, the position of the '<slot></slot>' in the template. This slot is meant to allow the user to describe the result of the query. For instance, if the result of the query is the number of samples, a good content of that slot would be the string 'Samples:', in order to display (for instance) 'Samples: 238' on the screen. However, since the slot was located at the right-hand side of the query result, this would have been displayed instead: '238 Samples:'.

Finally, we have simplified the logic of the 'fetch' call to remove duplicity and reduce the number of lines.

---

**Before:**

![image](https://github.com/line/promgen/assets/6151586/63b92cc2-ed42-4324-bf66-090fa00a6283)


**After:**

![image](https://github.com/line/promgen/assets/6151586/9a36ca8e-4723-4ed6-a0e1-04c84ccc07f2)
