### PR TITLE
[INTERNAL] Move proxy_error to util.proxy_error for reuse

### DIFF
--- a/promgen/util.py
+++ b/promgen/util.py
@@ -7,6 +7,7 @@ from urllib.parse import urlsplit
 import requests
 from django.conf import settings
 from django.db.models import F
+from django.http import HttpResponse
 
 # Wrappers around request api to ensure we always attach our user agent
 # https://github.com/requests/requests/blob/master/requests/api.py
@@ -119,6 +120,22 @@ def help_text(klass):
         return klass._meta.get_field(field).help_text
 
     return wrapped
+
+def proxy_error(response: requests.Response) -> HttpResponse:
+    """
+    Return a wrapped proxy error
+
+    Taking a request.response object as input, return it slightly modified
+    with an extra header for debugging so that we can see where the request
+    failed
+    """
+    r = HttpResponse(
+        response.content,
+        content_type=response.headers["content-type"],
+        status=response.status_code,
+    )
+    r.setdefault("X-PROMGEN-PROXY", response.url)
+    return r
 
 
 # Comment wrappers to get the docstrings from the upstream functions

--- a/promgen/views.py
+++ b/promgen/views.py
@@ -1404,10 +1404,6 @@ class PromqlQuery(View):
             response = util.get(f"{shard.url}/api/v1/query", params=params, headers=headers)
             response.raise_for_status()
         except HTTPError:
-            return HttpResponse(
-                response.content,
-                content_type=response.headers["content-type"],
-                status=response.status_code,
-            )
+            return util.proxy_error(response)
 
         return HttpResponse(response.content, content_type="application/json")


### PR DESCRIPTION
We can move our proxy_error wrapper so that it can be reused in our PromqlQuery View to keep things consistent.