### PR TITLE
Add test for URL rendering

### DIFF
--- a/promgen/fixtures/testcases.yaml
+++ b/promgen/fixtures/testcases.yaml
@@ -70,3 +70,13 @@
     job: node
     port: 9100
     enabled: false
+- model: promgen.probe
+  pk: 1
+  fields:
+    module: fixture_test
+- model: promgen.url
+  pk: 1
+  fields:
+    project: 1
+    probe: 1
+    url: probe.example.com

--- a/promgen/rest.py
+++ b/promgen/rest.py
@@ -39,6 +39,13 @@ class AllViewSet(viewsets.ViewSet):
             content_type="application/json",
         )
 
+    @action(detail=False, methods=["get"], renderer_classes=[renderers.renderers.JSONRenderer])
+    def urls(self, request):
+        return HttpResponse(
+            prometheus.render_urls(),
+            content_type="application/json",
+        )
+
 
 class ShardViewSet(viewsets.ModelViewSet):
     queryset = models.Shard.objects.all()

--- a/promgen/templates/promgen/navbar.html
+++ b/promgen/templates/promgen/navbar.html
@@ -36,7 +36,7 @@
                         <li><a href="{% url 'api:api-root' %}">API</a></li>
                         <li><a href="{% url 'api:all-targets' %}">Export Targets</a></li>
                         <li><a href="{% url 'api:all-rules' %}">Export Rules</a></li>
-                        <li><a href="{% url 'config-urls' %}">Export URL</a></li>
+                        <li><a href="{% url 'api:all-urls' %}">Export URLs</a></li>
                     </ul>
                 </li>
                 {% include 'promgen/help_menu.inc.html' %}

--- a/promgen/tests/examples/export.urls.json
+++ b/promgen/tests/examples/export.urls.json
@@ -1,0 +1,12 @@
+[
+  {
+    "labels": {
+      "__param_module": "fixture_test",
+      "__shard": "test-shard",
+      "job": "fixture_test",
+      "project": "test-project",
+      "service": "test-service"
+    },
+    "targets": ["probe.example.com"]
+  }
+]

--- a/promgen/tests/test_renderers.py
+++ b/promgen/tests/test_renderers.py
@@ -23,3 +23,9 @@ class RendererTests(tests.PromgenTest):
         response = self.client.get(reverse("api:all-targets"))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), expected)
+
+    def test_global_urls(self):
+        expected = tests.Data("examples", "export.urls.json").json()
+        response = self.client.get(reverse("api:all-urls"))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), expected)


### PR DESCRIPTION
Similar to our previous PR, we want to add some starting test cases to our url rendering paths so that we are prepared for future updates.