### PR TITLE
Update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @line/promgen
+* @line/promgen @kfdm


### PR DESCRIPTION
Adding myself to CODEOWNERS directly since I am no longer directly part of the line/promgen group. This allows me to still get automatically added to PR notifications.