### PR TITLE
Update translate tag

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -8,3 +8,5 @@ af2c352786f952d819e69b928bf6c99dcde5954b
 5821434b42203b1080dcdc480d1ffcf07fe53a90
 # Format with Ruff
 e72aba6d7e5891ac777f533eef6f7520410c9e0b
+# Update translate tag.
+8c4d552eedba195286c6fbadc2fae3b989cc15f7

--- a/promgen/templates/promgen/alert_row.html
+++ b/promgen/templates/promgen/alert_row.html
@@ -20,5 +20,5 @@
     </dl>
 </td>
 <td>
-    <a @click="setSilenceLabels(alert.labels)" class="btn btn-warning btn-xs">{% trans "Silence" %}</a>
+    <a @click="setSilenceLabels(alert.labels)" class="btn btn-warning btn-xs">{% translate "Silence" %}</a>
 </td>

--- a/promgen/templates/promgen/exporter_form.html
+++ b/promgen/templates/promgen/exporter_form.html
@@ -38,7 +38,7 @@
           <div class="input-group-btn">
             <button class="btn btn-primary">Register Exporter</button>
             <exporter-test class="btn btn-info" href="{% url 'exporter-scrape' project.id %}">
-              {% trans "Test" %}
+              {% translate "Test" %}
             </exporter-test>
           </div>
         </div>
@@ -61,7 +61,7 @@
           <div class="input-group-btn">
             <button style="width:80%" class="btn btn-primary" v-pre>Register {{ default.job }} :{{ default.port }}{{ default.path }}</button>
             <exporter-test class="btn btn-info" href="{% url 'exporter-scrape' project.id %}">
-              {% trans "Test" %}
+              {% translate "Test" %}
             </exporter-test>
           </div>
         </form>

--- a/promgen/templates/promgen/farm_detail.html
+++ b/promgen/templates/promgen/farm_detail.html
@@ -42,7 +42,7 @@
 
     <div class="panel-footer">
   {% if farm.editable %}
-      <a href="{% url 'hosts-add' farm.id %}" class="btn btn-primary">{% trans "Register Hosts" %}</a>
+      <a href="{% url 'hosts-add' farm.id %}" class="btn btn-primary">{% translate "Register Hosts" %}</a>
   {% endif %}
     <form method="post" action="{% url 'farm-delete' farm.id %}" onsubmit="return confirm('Delete this farm?')" style="display: inline">
       {% csrf_token %}

--- a/promgen/templates/promgen/farm_list.html
+++ b/promgen/templates/promgen/farm_list.html
@@ -50,12 +50,12 @@
         {% if farm.driver.remote %}
         <form method="post" action="{% url 'farm-convert' farm.id %}" onsubmit="return confirm('Convert this farm to local?')" style="display: inline">
           {% csrf_token %}
-          <button class="btn btn-warning">{% trans "Convert to Local Farm" %}</button>
+          <button class="btn btn-warning">{% translate "Convert to Local Farm" %}</button>
         </form>
         {% endif %}
         <form method="post" action="{% url 'farm-delete' farm.id %}" onsubmit="return confirm('Delete this farm?')" style="display: inline">
           {% csrf_token %}
-          <button class="btn btn-danger">{% trans "Delete" %}</button>
+          <button class="btn btn-danger">{% translate "Delete" %}</button>
         </form>
       </td>
     </tr>

--- a/promgen/templates/promgen/host_detail.html
+++ b/promgen/templates/promgen/host_detail.html
@@ -23,7 +23,7 @@
     class="btn btn-warning"
     data-instance="{{slug}}:[0-9]*"
     style="display: inline-block;"
-  >{% trans "Silence" %}</a>
+  >{% translate "Silence" %}</a>
   </div>
 </div>
 

--- a/promgen/templates/promgen/host_form.html
+++ b/promgen/templates/promgen/host_form.html
@@ -18,7 +18,7 @@
   <table>
     {{ form.as_table }}
   </table>
-  <input type="submit" value="{% trans 'Register Hosts' %}" />
+  <input type="submit" value="{% translate 'Register Hosts' %}" />
 </form>
 
 {% endblock %}

--- a/promgen/templates/promgen/profile.html
+++ b/promgen/templates/promgen/profile.html
@@ -26,16 +26,16 @@
         {% endfor %}
       </td>
       <td>
-        <a href="{% url 'notifier-edit' notifier.id %}" class="btn btn-warning btn-xs">{% trans "Edit" %}</a>
+        <a href="{% url 'notifier-edit' notifier.id %}" class="btn btn-warning btn-xs">{% translate "Edit" %}</a>
         <form method="post" action="{% url 'notifier-test' notifier.id %}" style="display: inline">
           {% csrf_token %}
           <input name="next" type="hidden" value="{{ request.get_full_path }}" />
-          <button class="btn btn-info btn-xs">{% trans "Test" %}</button>
+          <button class="btn btn-info btn-xs">{% translate "Test" %}</button>
         </form>
-        <form method="post" action="{% url 'notifier-delete' notifier.id %}" onsubmit="return confirm('{% trans "Delete notification?" %}')" style="display: inline">
+        <form method="post" action="{% url 'notifier-delete' notifier.id %}" onsubmit="return confirm('{% translate "Delete notification?" %}')" style="display: inline">
           {% csrf_token %}
           <input name="next" type="hidden" value="{{ request.get_full_path }}" />
-          <button class="btn btn-danger btn-xs">{% trans "Delete" %}</button>
+          <button class="btn btn-danger btn-xs">{% translate "Delete" %}</button>
         </form>
       </td>
     </tr>

--- a/promgen/templates/promgen/project_detail.html
+++ b/promgen/templates/promgen/project_detail.html
@@ -12,7 +12,7 @@ Promgen / Project / {{ project.name }}
   <h1>
     Project: {{ project.name }}
     {% if project.owner %}
-    <small class="pull-right">{% trans 'Contact' %}: {{project.owner.username}}</small>
+    <small class="pull-right">{% translate 'Contact' %}: {{project.owner.username}}</small>
     {% endif %}
   </h1>
 </div>
@@ -23,7 +23,7 @@ Promgen / Project / {{ project.name }}
 <div class="alert alert-warning" role="alert">
   <span class="glyphicon glyphicon-alert" aria-hidden="true"></span>
   <span class="sr-only">Warning:</span>
-  {% trans 'No notifications configured for this project. Please configure some' %}
+  {% translate 'No notifications configured for this project. Please configure some' %}
 </div>
 {% endif %}
 

--- a/promgen/templates/promgen/project_detail_configuration.html
+++ b/promgen/templates/promgen/project_detail_configuration.html
@@ -6,47 +6,47 @@
   <div class="panel-body">
     <div class="btn-group btn-group-sm" role="group" aria-label="...">
       <button type="button" class="btn btn-primary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-        {% trans "Register" %} <span class="caret"></span>
+        {% translate "Register" %} <span class="caret"></span>
       </button>
       <ul class="dropdown-menu">
-        <li role="presentation"><a href="{% url 'project-exporter' project.id %}">{% trans "Register Exporter" %}</a></li>
-        <li role="presentation"><a href="{% url 'rule-new' 'project' project.id %}">{% trans "Register Rule" %}</a></li>
-        <li role="presentation"><a href="{% url 'project-notifier' project.id %}">{% trans "Register Notifier" %}</a></li>
+        <li role="presentation"><a href="{% url 'project-exporter' project.id %}">{% translate "Register Exporter" %}</a></li>
+        <li role="presentation"><a href="{% url 'rule-new' 'project' project.id %}">{% translate "Register Rule" %}</a></li>
+        <li role="presentation"><a href="{% url 'project-notifier' project.id %}">{% translate "Register Notifier" %}</a></li>
       </ul>
     </div>
 
     <form action="{% url 'project-notifier' project.id %}" style="display:inline" method="post">{% csrf_token %}
       <input type="hidden" name="sender" value="promgen.notification.user">
       <input type="hidden" name="value" value="{{request.user.username}}" />
-      <button class="btn btn-primary btn-sm">{% trans "Subscribe to Notifications" %}</button>
+      <button class="btn btn-primary btn-sm">{% translate "Subscribe to Notifications" %}</button>
     </form>
 
     <div class="btn-group btn-group-sm" role="group" aria-label="...">
       <button type="button" class="btn btn-info dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-        {% trans "Change History" %} <span class="caret"></span>
+        {% translate "Change History" %} <span class="caret"></span>
       </button>
       <ul class="dropdown-menu">
-        <li role="presentation"><a href="{% urlqs 'audit-list' project=project.id  %}">{% trans "Edit History" %}</a></li>
-        <li role="presentation"><a href="{% urlqs 'alert-list' project=project.name %}">{% trans "Alert History" %}</a></li>
+        <li role="presentation"><a href="{% urlqs 'audit-list' project=project.id  %}">{% translate "Edit History" %}</a></li>
+        <li role="presentation"><a href="{% urlqs 'alert-list' project=project.name %}">{% translate "Alert History" %}</a></li>
       </ul>
     </div>
 
-    <a href="{% url 'project-update' project.id %}" class="btn btn-warning btn-sm">{% trans "Update Project" %}</a>
-    <a @click="setSilenceDataset" class="btn btn-warning btn-sm" data-project="{{project.name}}" data-service="{{project.service.name}}">{% trans "Silence" %}</a>
+    <a href="{% url 'project-update' project.id %}" class="btn btn-warning btn-sm">{% translate "Update Project" %}</a>
+    <a @click="setSilenceDataset" class="btn btn-warning btn-sm" data-project="{{project.name}}" data-service="{{project.service.name}}">{% translate "Silence" %}</a>
 
     <div class="btn-group btn-group-sm" role="group" aria-label="...">
       <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
         Export <span class="caret"></span>
       </button>
       <ul class="dropdown-menu">
-        <li role="presentation"><a href="{% url 'api:project-rules' name=project.name %}">{% trans "Export Rules" %}</a></li>
-        <li role="presentation"><a href="{% url 'api:project-targets' name=project.name %}">{% trans "Export Project" %}</a></li>
+        <li role="presentation"><a href="{% url 'api:project-rules' name=project.name %}">{% translate "Export Rules" %}</a></li>
+        <li role="presentation"><a href="{% url 'api:project-targets' name=project.name %}">{% translate "Export Project" %}</a></li>
       </ul>
     </div>
 
-    <form method="post" action="{% url 'project-delete' project.id %}" onsubmit="return confirm('{% trans " Delete this Project?" %}')" style="display: inline">
+    <form method="post" action="{% url 'project-delete' project.id %}" onsubmit="return confirm('{% translate " Delete this Project?" %}')" style="display: inline">
       {% csrf_token %}
-      <button class="btn btn-danger btn-sm pull-right">{% trans "Delete Project" %}</button>
+      <button class="btn btn-danger btn-sm pull-right">{% translate "Delete Project" %}</button>
     </form>
   </div>
 

--- a/promgen/templates/promgen/project_detail_exporters.html
+++ b/promgen/templates/promgen/project_detail_exporters.html
@@ -32,7 +32,7 @@
           <input type="hidden" name="port" value="{{ exporter.port }}" />
           <input type="hidden" name="path" value="{{ exporter.path }}" />
           <exporter-test class="btn btn-info btn-xs" href="{% url 'exporter-scrape' project.id %}">
-            {% trans "Test" %}
+            {% translate "Test" %}
           </exporter-test>
         </form>
       </td>
@@ -44,19 +44,19 @@
           data-project="{{project.name}}"
           data-service="{{project.service.name}}"
           style="display: inline-block;"
-        >{% trans "Silence" %}</a>
+        >{% translate "Silence" %}</a>
       </td>
       <td>
-        <form method="post" action="{% url 'exporter-delete' exporter.id %}" onsubmit="return confirm('{% trans 'Delete this exporter?' %}')" style="display: inline">
+        <form method="post" action="{% url 'exporter-delete' exporter.id %}" onsubmit="return confirm('{% translate 'Delete this exporter?' %}')" style="display: inline">
           {% csrf_token %}
-          <button class="btn btn-danger btn-xs">{% trans "Delete" %}</button>
+          <button class="btn btn-danger btn-xs">{% translate "Delete" %}</button>
         </form>
       </td>
     </tr>
   {% endfor %}
   </table>
   <div class="panel-footer">
-    <a href="{% url 'project-exporter' project.id %}" class="btn btn-primary">{% trans "Register Exporter" %}</a>
+    <a href="{% url 'project-exporter' project.id %}" class="btn btn-primary">{% translate "Register Exporter" %}</a>
   </div>
 </div>
 

--- a/promgen/templates/promgen/project_detail_hosts.html
+++ b/promgen/templates/promgen/project_detail_hosts.html
@@ -22,13 +22,13 @@
           data-project="{{project.name}}"
           data-service="{{project.service.name}}"
           style="display: inline-block;"
-        >{% trans "Silence" %}</a>
+        >{% translate "Silence" %}</a>
       </td>
       {% if project.farm.editable %}
       <td>
-        <form method="post" action="{% url 'host-delete' host.id %}" onsubmit="return confirm('{% trans "Delete this host?" %}');">
+        <form method="post" action="{% url 'host-delete' host.id %}" onsubmit="return confirm('{% translate "Delete this host?" %}');">
           {% csrf_token %}
-        <button name="delete" type="submit" class="btn btn-danger btn-xs">{% trans "Delete" %}</button>
+        <button name="delete" type="submit" class="btn btn-danger btn-xs">{% translate "Delete" %}</button>
         </form>
       </td>
       {% endif %}
@@ -44,14 +44,14 @@
       data-service="{{project.service.name}}"
       style="display: inline-block;"
       v-if="selectedHosts.length"
-    >{% trans "Silence selected hosts" %}</a>
+    >{% translate "Silence selected hosts" %}</a>
 {% if project.farm %}
   {% if project.farm.editable %}
     <a href="{% url 'hosts-add' project.farm.id %}" class="btn btn-primary">
-      {% trans "Register Hosts" %}
+      {% translate "Register Hosts" %}
     </a>
     <a href="{% url 'farm-update' project.farm.id %}" class="btn btn-default">
-      {% trans "Edit Farm" %}
+      {% translate "Edit Farm" %}
     </a>
   {% else %}
     <form method="post" action="{% url 'farm-convert' project.farm.id %}" onsubmit="return confirm('Convert this farm to local?')" style="display: inline">
@@ -59,7 +59,7 @@
       <input name="next" type="hidden" value="{{ request.get_full_path }}" />
       <button class="btn btn-warning">
         <span class="glyphicon glyphicon-cloud-download" aria-hidden="true"></span>
-        {% trans "Convert to Local Farm" %}
+        {% translate "Convert to Local Farm" %}
       </button>
     </form>
     <form method="post" action="{% url 'farm-refresh' project.farm.id %}" style="display: inline">
@@ -67,27 +67,27 @@
       <input name="next" type="hidden" value="{{ request.get_full_path }}" />
       <button type="submit" class="btn btn-warning">
         <span class="glyphicon glyphicon-cloud-download" aria-hidden="true"></span>
-        {% trans "Sync Farm" %}
+        {% translate "Sync Farm" %}
       </button>
     </form>
   {% endif %}
-  <form method="post" action="{% url 'farm-unlink' project.id %}" onsubmit="return confirm('{% trans "Unlink this farm?" %}')" style="display: inline">
+  <form method="post" action="{% url 'farm-unlink' project.id %}" onsubmit="return confirm('{% translate "Unlink this farm?" %}')" style="display: inline">
     {% csrf_token %}
     <button type="submit" class="btn btn-danger">
       {% if source.remote %}
         <span class="glyphicon glyphicon-cloud-download" aria-hidden="true"></span>
       {% endif %}
-      {% trans "Unlink Farm" %}
+      {% translate "Unlink Farm" %}
     </button>
   </form>
 {% else %}
-    <a href="{% url 'farm-new' project.id %}" class="btn btn-primary">{% trans "Register Farm" %}</a>
+    <a href="{% url 'farm-new' project.id %}" class="btn btn-primary">{% translate "Register Farm" %}</a>
 {% for name, source in sources %}
     <a href="{% url 'farm-link' project.id name %}" class="btn btn-default" v-pre>
       {% if source.remote %}
         <span class="glyphicon glyphicon-cloud-download" aria-hidden="true"></span>
       {% endif %}
-      {% trans "Link Farm" %} {{ name }}
+      {% translate "Link Farm" %} {{ name }}
     </a>
 {% endfor %}
 {% endif %}

--- a/promgen/templates/promgen/project_detail_notifiers.html
+++ b/promgen/templates/promgen/project_detail_notifiers.html
@@ -16,11 +16,11 @@
   <div class="panel-heading">Project Notifiers</div>
   {% include "promgen/notifier_block.html" with object=project show_edit=1 %}
   <div class="panel-footer" v-pre>
-    <a href="{% url 'project-notifier' project.id %}" class="btn btn-primary">{% trans "Register Notifier" %}</a>
+    <a href="{% url 'project-notifier' project.id %}" class="btn btn-primary">{% translate "Register Notifier" %}</a>
     <form action="{% url 'project-notifier' project.id %}" style="display:inline" method="post">{% csrf_token %}
       <input type="hidden" name="sender" value="promgen.notification.user">
       <input type="hidden" name="value" value="{{request.user.username}}" />
-      <button class="btn btn-primary">{% trans "Subscribe to Notifications" %}</button>
+      <button class="btn btn-primary">{% translate "Subscribe to Notifications" %}</button>
     </form>
   </div>
 </div>

--- a/promgen/templates/promgen/project_detail_rules.html
+++ b/promgen/templates/promgen/project_detail_rules.html
@@ -12,10 +12,10 @@
   </table>
   <div class="panel-footer">
     <a class="btn btn-default btn-xs" role="button" data-toggle="collapse" href=".project-service-rules-{{project.id}}" aria-expanded="false" aria-controls="collapseExample">
-      {% trans 'Show Service Rules' %}
+      {% translate 'Show Service Rules' %}
     </a>
     <a class="btn btn-default btn-xs" role="button" data-toggle="collapse" href=".project-site-rules-{{project.id}}" aria-expanded="false" aria-controls="collapseExample">
-      {% trans 'Show Site Rules' %}
+      {% translate 'Show Site Rules' %}
     </a>
   </div>
 </div>

--- a/promgen/templates/promgen/project_detail_urls.html
+++ b/promgen/templates/promgen/project_detail_urls.html
@@ -16,7 +16,7 @@
         <a @click="setSilenceDataset"
           class="btn btn-warning btn-xs"
           data-job="{{url.probe.module}}"
-          data-instance="{{url.url}}">{% trans "Silence" %}</a>
+          data-instance="{{url.url}}">{% translate "Silence" %}</a>
       </td>
       <td>
         <form method="post"
@@ -24,7 +24,7 @@
           onsubmit="return confirm('Delete this url?')"
           style="display: inline">
           {% csrf_token %}
-          <button class="btn btn-danger btn-xs">{% trans "Delete" %}</button>
+          <button class="btn btn-danger btn-xs">{% translate "Delete" %}</button>
         </form>
       </td>
     </tr>
@@ -36,7 +36,7 @@
       {{url_form.as_table}}
     </table>
     <div class="panel-footer">
-      <button class="btn btn-primary btn-sm">{% trans "Register URL" %}</button>
+      <button class="btn btn-primary btn-sm">{% translate "Register URL" %}</button>
     </div>
   </form>
 </div>

--- a/promgen/templates/promgen/project_row.html
+++ b/promgen/templates/promgen/project_row.html
@@ -13,7 +13,7 @@
             {% empty %}
             <tr>
                 <td colspan="3">
-                    <a href="{% url 'project-exporter' project.id %}" class="btn btn-primary btn-xs">{% trans "Register Exporter" %}</a>
+                    <a href="{% url 'project-exporter' project.id %}" class="btn btn-primary btn-xs">{% translate "Register Exporter" %}</a>
                 </td>
             </tr>
             {% endfor %}
@@ -30,7 +30,7 @@
             {% empty %}
             <tr>
                 <td colspan="2">
-                    <a href="{% url 'project-notifier' project.id %}" class="btn btn-primary btn-xs">{% trans "Register Notifier" %}</a>
+                    <a href="{% url 'project-notifier' project.id %}" class="btn btn-primary btn-xs">{% translate "Register Notifier" %}</a>
                 </td>
             </tr>
             {% endfor %}
@@ -38,6 +38,6 @@
     </td>
 
     <td>
-        <a @click="setSilenceDataset" class="btn btn-warning btn-xs" data-project="{{project.name}}" data-service="{{service.name}}">{% trans "Silence" %}</a>
+        <a @click="setSilenceDataset" class="btn btn-warning btn-xs" data-project="{{project.name}}" data-service="{{service.name}}">{% translate "Silence" %}</a>
     </td>
 </tr>

--- a/promgen/templates/promgen/rule_block.html
+++ b/promgen/templates/promgen/rule_block.html
@@ -5,7 +5,7 @@
   <td>
     <a title="{{rule.description}}" data-toggle="tooltip" data-placement="right" href="{% url 'rule-detail' rule.id %}" v-pre>{{ rule.name }}</a>
     {% if rule.parent %}
-    <a class="pull-right" title="{% trans "View Parent" %}" href="{% url 'rule-detail' rule.parent.id %}">
+    <a class="pull-right" title="{% translate "View Parent" %}" href="{% url 'rule-detail' rule.parent.id %}">
       <span class="glyphicon glyphicon-upload"></span>
     </a>
     {% endif %}
@@ -34,14 +34,14 @@
       <input name="content_type" type="hidden" value="{{overwrite_type}}" />
       <input name="object_id" type="hidden" value="{{overwrite_id}}" />
       {% csrf_token %}
-      <button class="btn btn-warning btn-xs">{% trans "Overwrite" %}</button>
+      <button class="btn btn-warning btn-xs">{% translate "Overwrite" %}</button>
     </form>
   </td>
   {% else %}
   <td>
-    <form method="post" action="{% url 'rule-delete' rule.id %}" onsubmit="return confirm('{% trans "Delete this Rule?" %}')" style="display: inline">
+    <form method="post" action="{% url 'rule-delete' rule.id %}" onsubmit="return confirm('{% translate "Delete this Rule?" %}')" style="display: inline">
       {% csrf_token %}
-      <button class="btn btn-danger btn-xs">{% trans "Delete" %}</button>
+      <button class="btn btn-danger btn-xs">{% translate "Delete" %}</button>
     </form>
   </td>
   {% endif %}

--- a/promgen/templates/promgen/rule_detail.html
+++ b/promgen/templates/promgen/rule_detail.html
@@ -37,8 +37,8 @@ Promgen / Rule / {{ rule.name }}
         <pre v-pre>{{rule|rule_dict|pretty_yaml}}</pre>
     </div>
     <div class="panel-footer">
-        <a href="{% url 'rule-edit' rule.pk %}" class="btn btn-warning btn-sm">{% trans "Edit Rule" %}</a>
-        <a href="{% urlqs 'alert-list' alertname=rule.name %}" class="btn btn-info btn-sm">{% trans "Alert History" %}</a>
+        <a href="{% url 'rule-edit' rule.pk %}" class="btn btn-warning btn-sm">{% translate "Edit Rule" %}</a>
+        <a href="{% urlqs 'alert-list' alertname=rule.name %}" class="btn btn-info btn-sm">{% translate "Alert History" %}</a>
     </div>
 </div>
 

--- a/promgen/templates/promgen/rule_list.html
+++ b/promgen/templates/promgen/rule_list.html
@@ -18,7 +18,7 @@
 <div class="panel panel-default">
   <div class="panel-heading" v-pre>
     <a href="{{ group.grouper.get_absolute_url }}">{{ group.grouper }}</a>
-    <a href="{% url 'rule-new' group.grouper|klass|lower group.grouper.id %}" class="btn btn-primary btn-xs pull-right">{% trans "Register Rule" %}</a>
+    <a href="{% url 'rule-new' group.grouper|klass|lower group.grouper.id %}" class="btn btn-primary btn-xs pull-right">{% translate "Register Rule" %}</a>
   </div>
 
   <table class="table table-bordered table-condensed">

--- a/promgen/templates/promgen/rule_update.html
+++ b/promgen/templates/promgen/rule_update.html
@@ -92,17 +92,17 @@ Promgen / Rule / {{ rule.name }}
   <div class="panel panel-primary">
     <div class="panel-body">
       <button class="btn btn-primary">Save Rule</button>
-      <a href="{% urlqs 'audit-list' rule=rule.id %}" class="btn btn-info">{% trans "Edit History" %}</a>
-      <a href="{% urlqs 'alert-list' alertname=rule.name %}" class="btn btn-info">{% trans "Alert History" %}</a>
+      <a href="{% urlqs 'audit-list' rule=rule.id %}" class="btn btn-info">{% translate "Edit History" %}</a>
+      <a href="{% urlqs 'alert-list' alertname=rule.name %}" class="btn btn-info">{% translate "Alert History" %}</a>
     </div>
   </div>
 </form>
 
 <div class="panel panel-danger">
   <div class="panel-body">
-    <form method="post" action="{% url 'rule-delete' rule.id %}" onsubmit="return confirm('{% trans " Delete this Rule?" %}')" style="display: inline">
+    <form method="post" action="{% url 'rule-delete' rule.id %}" onsubmit="return confirm('{% translate " Delete this Rule?" %}')" style="display: inline">
       {% csrf_token %}
-      <button class="btn btn-danger">{% trans "Delete Rule" %}</button>
+      <button class="btn btn-danger">{% translate "Delete Rule" %}</button>
     </form>
   </div>
 </div>

--- a/promgen/templates/promgen/search.html
+++ b/promgen/templates/promgen/search.html
@@ -89,7 +89,7 @@
             class="btn btn-warning btn-xs"
             data-instance="{{host.name}}:[0-9]*"
             style="display: inline-block;"
-          >{% trans "Silence" %}</a></li>
+          >{% translate "Silence" %}</a></li>
 {% endfor %}
         </ul>
       </td>
@@ -111,7 +111,7 @@
           class="btn btn-warning btn-xs"
           data-instance="{{host.name}}:[0-9]*"
           style="display: inline-block;"
-        >{% trans "Silence" %}</a></td>
+        >{% translate "Silence" %}</a></td>
       </tr>
     {% endfor %}
   </table>

--- a/promgen/templates/promgen/sender_row.html
+++ b/promgen/templates/promgen/sender_row.html
@@ -36,15 +36,15 @@
             data-csrfmiddlewaretoken="{{csrf_token}}"
             data-action="{% url 'notifier-toggle' notifier.id %}"
         />
-        <a href="{% url 'notifier-edit' notifier.id %}" class="btn btn-warning btn-xs">{% trans "Edit" %}</a>
+        <a href="{% url 'notifier-edit' notifier.id %}" class="btn btn-warning btn-xs">{% translate "Edit" %}</a>
         <form method="post" action="{% url 'notifier-test' notifier.id %}" style="display: inline">
             {% csrf_token %}
             <input name="next" type="hidden" value="{{ request.get_full_path }}" />
-            <button class="btn btn-info btn-xs">{% trans "Test" %}</button>
+            <button class="btn btn-info btn-xs">{% translate "Test" %}</button>
         </form>
-        <form method="post" action="{% url 'notifier-delete' notifier.id %}" onsubmit="return confirm('{% trans "Delete notification?" %}')" style="display: inline">
+        <form method="post" action="{% url 'notifier-delete' notifier.id %}" onsubmit="return confirm('{% translate "Delete notification?" %}')" style="display: inline">
             {% csrf_token %}
-            <button class="btn btn-danger btn-xs">{% trans "Delete" %}</button>
+            <button class="btn btn-danger btn-xs">{% translate "Delete" %}</button>
         </form>
     </td>
     {% endif %}

--- a/promgen/templates/promgen/service_block.html
+++ b/promgen/templates/promgen/service_block.html
@@ -37,47 +37,47 @@
     <div class="panel-body">
       <div class="btn-group btn-group-sm" role="group" aria-label="...">
         <button type="button" class="btn btn-primary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          {% trans "Register" %} <span class="caret"></span>
+          {% translate "Register" %} <span class="caret"></span>
         </button>
         <ul class="dropdown-menu">
-          <li role="presentation"><a href="{% url 'project-new' service.id %}">{% trans "Register Project" %}</a></li>
-          <li role="presentation"><a href="{% url 'rule-new' 'service' service.id %}">{% trans "Register Rule" %}</a></li>
-          <li role="presentation"><a href="{% url 'service-notifier' service.id %}">{% trans "Register Notifier" %}</a></li>
+          <li role="presentation"><a href="{% url 'project-new' service.id %}">{% translate "Register Project" %}</a></li>
+          <li role="presentation"><a href="{% url 'rule-new' 'service' service.id %}">{% translate "Register Rule" %}</a></li>
+          <li role="presentation"><a href="{% url 'service-notifier' service.id %}">{% translate "Register Notifier" %}</a></li>
         </ul>
       </div>
 
       <form action="{% url 'service-notifier' service.id %}" style="display:inline" method="post" v-pre>{% csrf_token %}
         <input type="hidden" name="sender" value="promgen.notification.user">
         <input type="hidden" name="value" value="{{request.user.username}}" />
-        <button class="btn btn-primary btn-sm">{% trans "Subscribe to Notifications" %}</button>
+        <button class="btn btn-primary btn-sm">{% translate "Subscribe to Notifications" %}</button>
       </form>
 
       <div class="btn-group btn-group-sm" role="group" aria-label="...">
         <button type="button" class="btn btn-info dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          {% trans "Change History" %} <span class="caret"></span>
+          {% translate "Change History" %} <span class="caret"></span>
         </button>
         <ul class="dropdown-menu">
-          <li role="presentation"><a href="{% urlqs 'audit-list' service=service.id %}">{% trans "Edit History" %}</a></li>
-          <li role="presentation"><a href="{% urlqs 'alert-list' service=service.name %}">{% trans "Alert History" %}</a></li>
+          <li role="presentation"><a href="{% urlqs 'audit-list' service=service.id %}">{% translate "Edit History" %}</a></li>
+          <li role="presentation"><a href="{% urlqs 'alert-list' service=service.name %}">{% translate "Alert History" %}</a></li>
         </ul>
       </div>
 
-      <a href="{% url 'service-update' service.id %}" class="btn btn-warning btn-sm">{% trans "Edit Service" %}</a>
-      <a @click="setSilenceDataset" data-service="{{service.name}}" class="btn btn-warning btn-sm">{% trans "Silence" %}</a>
+      <a href="{% url 'service-update' service.id %}" class="btn btn-warning btn-sm">{% translate "Edit Service" %}</a>
+      <a @click="setSilenceDataset" data-service="{{service.name}}" class="btn btn-warning btn-sm">{% translate "Silence" %}</a>
 
       <div class="btn-group btn-group-sm" role="group" aria-label="...">
         <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
           Export <span class="caret"></span>
         </button>
         <ul class="dropdown-menu">
-          <li role="presentation"><a href="{% url 'api:service-rules' name=service.name %}">{% trans "Export Rules" %}</a></li>
-          <li role="presentation"><a href="{% url 'api:service-targets' name=service.name %}">{% trans "Export Service" %}</a></li>
+          <li role="presentation"><a href="{% url 'api:service-rules' name=service.name %}">{% translate "Export Rules" %}</a></li>
+          <li role="presentation"><a href="{% url 'api:service-targets' name=service.name %}">{% translate "Export Service" %}</a></li>
         </ul>
       </div>
 
-      <form method="post" action="{% url 'service-delete' service.id %}" onsubmit="return confirm('{% trans "Delete this service?" %}')" style="display: inline">
+      <form method="post" action="{% url 'service-delete' service.id %}" onsubmit="return confirm('{% translate "Delete this service?" %}')" style="display: inline">
         {% csrf_token %}
-        <button class="btn btn-danger btn-sm pull-right">{% trans "Delete Service" %}</button>
+        <button class="btn btn-danger btn-sm pull-right">{% translate "Delete Service" %}</button>
       </form>
     </div>
   </div>
@@ -91,7 +91,7 @@
     </table>
     <div class="panel-footer">
       <a class="btn btn-default btn-xs" role="button" data-toggle="collapse" href=".service-site-rules-{{service.id}}" aria-expanded="false" aria-controls="collapseExample">
-        {% trans 'Show Site Rules' %}
+        {% translate 'Show Site Rules' %}
       </a>
     </div>
   </div>

--- a/promgen/templates/promgen/service_block_projects.html
+++ b/promgen/templates/promgen/service_block_projects.html
@@ -8,7 +8,7 @@
         Datasource
         <a href="{{shard.get_absolute_url}}">{{shard.name}}</a>
         ( <a href="{{shard.url}}">{{shard.url}}</a> )
-        <a href="{% url 'project-new' service.id %}?shard={{shard.id}}" class="btn btn-primary btn-xs pull-right">{% trans "Register Project" %}</a>
+        <a href="{% url 'project-new' service.id %}?shard={{shard.id}}" class="btn btn-primary btn-xs pull-right">{% translate "Register Project" %}</a>
     </div>
     <table class="table table-bordered table-condensed">
         <tr>
@@ -23,7 +23,7 @@
         <tr>
             <td colspan="4" class="warning">
                 <span class="glyphicon glyphicon-alert" aria-hidden="true"></span>
-                {% trans "No notifications configured for this project. Please configure some" %}
+                {% translate "No notifications configured for this project. Please configure some" %}
             </td>
         </tr>
         {% endif %}

--- a/promgen/templates/promgen/service_detail.html
+++ b/promgen/templates/promgen/service_detail.html
@@ -11,7 +11,7 @@ Promgen / Service / {{ service.name }}
 <div class="page-header" v-pre>
   <h1>Service: {{ service.name }}</h1>
   {% if service.owner %}
-  <p>{% trans 'Contact' %}: {{service.owner.username}}</p>
+  <p>{% translate 'Contact' %}: {{service.owner.username}}</p>
   {% endif %}
 </div>
 

--- a/promgen/templates/promgen/service_header.html
+++ b/promgen/templates/promgen/service_header.html
@@ -3,6 +3,6 @@
 <h2 v-pre>
     <a href="{% url 'service-detail' service.id %}">{{ service.name }}</a>
     {% if service.owner %}
-    <small class="pull-right">{% trans 'Contact' %}: {{service.owner.username}}</small>
+    <small class="pull-right">{% translate 'Contact' %}: {{service.owner.username}}</small>
     {% endif %}
 </h2>

--- a/promgen/templates/promgen/service_list.html
+++ b/promgen/templates/promgen/service_list.html
@@ -5,8 +5,8 @@
 {% block content %}
 
 <div class="page-header">
-  <h1>{% trans 'Services' %}</h1>
-  <a href="{% url 'service-new'  %}" class="btn btn-primary btn-sm float-right">{% trans "Register Service" %}</a>
+  <h1>{% translate 'Services' %}</h1>
+  <a href="{% url 'service-new'  %}" class="btn btn-primary btn-sm float-right">{% translate "Register Service" %}</a>
 </div>
 
 {% breadcrumb label="Services" %}

--- a/promgen/templates/promgen/shard_detail.html
+++ b/promgen/templates/promgen/shard_detail.html
@@ -26,7 +26,7 @@ Promgen / Datasource / {{ shard.name }}
       <h2>
         <a href="{% url 'service-detail' service.id %}">{{ service.name }}</a>
         {% if service.owner %}
-        <small class="pull-right">{% trans 'Contact' %}: {{service.owner.username}}</small>
+        <small class="pull-right">{% translate 'Contact' %}: {{service.owner.username}}</small>
         {% endif %}
       </h2>
 

--- a/promgen/templates/promgen/shard_header.html
+++ b/promgen/templates/promgen/shard_header.html
@@ -7,7 +7,7 @@
 
   {% if user.is_superuser %}
   <a class="btn btn-danger btn-sm pull-right" role="button" href="{% url 'admin:promgen_shard_change' shard.id %}">
-    {% trans "Admin" %}
+    {% translate "Admin" %}
   </a>
   {% endif %}
 </div>

--- a/promgen/templates/promgen/site_detail.html
+++ b/promgen/templates/promgen/site_detail.html
@@ -10,7 +10,7 @@ Promgen / Shared
 <div class="panel panel-default">
     <div class="panel-heading">
         <span>Site Alert Rules</span>
-        <a href="{% url 'rule-new' 'site' 1 %}" class="btn btn-primary btn-xs pull-right">{% trans "Register Rule" %}</a>
+        <a href="{% url 'rule-new' 'site' 1 %}" class="btn btn-primary btn-xs pull-right">{% translate "Register Rule" %}</a>
     </div>
 
     <table class="table table-bordered table-condensed">

--- a/promgen/templates/promgen/url_list.html
+++ b/promgen/templates/promgen/url_list.html
@@ -42,7 +42,7 @@
     <td class="col-md-1">
       <form method="post" action="{% url 'url-delete' url.id %}" onsubmit="return confirm('Delete this url?')" style="display: inline">
         {% csrf_token %}
-        <button class="btn btn-danger btn-xs">{% trans "Delete" %}</button>
+        <button class="btn btn-danger btn-xs">{% translate "Delete" %}</button>
       </form>
     </td>
   </tr>


### PR DESCRIPTION
Update translate tag.

Going forward, the translate tag is the recommended version so we update things for clarity.

https://docs.djangoproject.com/en/3.2/topics/i18n/translation/#std:templatetag-translate

> The trans tag was renamed to translate. The trans tag is still supported as an alias for backwards compatibility.

This will also help remove a bit of noise in #520 regarding some lines that only change the tag.