### PR TITLE
Service button group (Part 1)

### DIFF
--- a/promgen/locale/ja/LC_MESSAGES/django.po
+++ b/promgen/locale/ja/LC_MESSAGES/django.po
@@ -172,3 +172,7 @@ msgstr "Serviceを登録"
 #: templates/promgen/project_detail_hosts.html:49
 msgid "Silence selected hosts"
 msgstr "選択したHostをSilence"
+
+#: templates/promgen/service_detail.html:23
+msgid "Actions"
+msgstr "Actions"

--- a/promgen/static/css/promgen.css
+++ b/promgen/static/css/promgen.css
@@ -81,6 +81,29 @@ a[rel]:after {
   cursor: pointer;
 }
 
+
+/* service-detail */
+.promgen-flex-space-between-center {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+
+/* service-action-button-group */
+.service-action-button-group {
+  hr {
+    margin-top: 5px !important;
+    margin-bottom: 5px !important;
+  }
+  .dropdown-menu > li > form > button {
+    padding: 3px 20px;
+    white-space: nowrap;
+    background: none;
+    border: none;
+  }
+}
+
 /* Margin Top */
 .mt-0 { margin-top: 0 !important; }
 .mt-1 { margin-top: 0.25rem !important; }

--- a/promgen/templates/promgen/service_action_button_group.html
+++ b/promgen/templates/promgen/service_action_button_group.html
@@ -1,0 +1,44 @@
+{% load i18n %}
+{% load promgen %}
+
+<div style="display: inline-block;" class="service-action-button-group">
+  <div class="btn-group btn-group-sm" role="group" aria-label="...">
+    <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+      {% translate "Actions" %} <span class="caret"></span>
+    </button>
+    <ul class="dropdown-menu">
+
+      <li>
+        <form action="{% url 'service-notifier' service.id %}" style="display:inline" method="post" v-pre>{% csrf_token %}
+          <input type="hidden" name="sender" value="promgen.notification.user">
+          <input type="hidden" name="value" value="{{request.user.username}}" />
+          <button>{% translate "Subscribe to Notifications" %}</button>
+        </form>
+      </li>
+
+      <hr>
+
+      <li role="presentation"><a href="{% urlqs 'audit-list' service=service.id %}">{% translate "Edit History" %}</a></li>
+      <li role="presentation"><a href="{% urlqs 'alert-list' service=service.name %}">{% translate "Alert History" %}</a></li>
+
+      <hr>
+
+      <li role="presentation"><a href="{% url 'api:service-rules' name=service.name %}">{% translate "Export Rules" %}</a></li>
+      <li role="presentation"><a href="{% url 'api:service-targets' name=service.name %}">{% translate "Export Service" %}</a></li>
+
+      <hr>
+
+      <li role="presentation">
+        <form method="post" action="{% url 'service-delete' service.id %}" onsubmit="return confirm('{% translate "Delete this service?" %}')" style="display: inline">
+          {% csrf_token %}   
+          <button type="submit" style="color:#d9534f;">{% translate "Delete Service" %}</button>  
+        </form>
+      </li>
+
+    </ul>
+  </div>
+  <a @click="setSilenceDataset" data-service="{{service.name}}" class="btn btn-warning btn-sm ml-2 mr-2">{% translate "Silence" %}</a>
+
+  <a href="{% url 'service-update' service.id %}" class="btn btn-warning btn-sm">{% translate "Edit Service" %}</a>
+
+</div>

--- a/promgen/templates/promgen/service_block.html
+++ b/promgen/templates/promgen/service_block.html
@@ -33,55 +33,6 @@
   </div>
   {% endif %}
 
-  <div class="panel panel-default">
-    <div class="panel-body">
-      <div class="btn-group btn-group-sm" role="group" aria-label="...">
-        <button type="button" class="btn btn-primary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          {% trans "Register" %} <span class="caret"></span>
-        </button>
-        <ul class="dropdown-menu">
-          <li role="presentation"><a href="{% url 'project-new' service.id %}">{% trans "Register Project" %}</a></li>
-          <li role="presentation"><a href="{% url 'rule-new' 'service' service.id %}">{% trans "Register Rule" %}</a></li>
-          <li role="presentation"><a href="{% url 'service-notifier' service.id %}">{% trans "Register Notifier" %}</a></li>
-        </ul>
-      </div>
-
-      <form action="{% url 'service-notifier' service.id %}" style="display:inline" method="post" v-pre>{% csrf_token %}
-        <input type="hidden" name="sender" value="promgen.notification.user">
-        <input type="hidden" name="value" value="{{request.user.username}}" />
-        <button class="btn btn-primary btn-sm">{% trans "Subscribe to Notifications" %}</button>
-      </form>
-
-      <div class="btn-group btn-group-sm" role="group" aria-label="...">
-        <button type="button" class="btn btn-info dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          {% trans "Change History" %} <span class="caret"></span>
-        </button>
-        <ul class="dropdown-menu">
-          <li role="presentation"><a href="{% urlqs 'audit-list' service=service.id %}">{% trans "Edit History" %}</a></li>
-          <li role="presentation"><a href="{% urlqs 'alert-list' service=service.name %}">{% trans "Alert History" %}</a></li>
-        </ul>
-      </div>
-
-      <a href="{% url 'service-update' service.id %}" class="btn btn-warning btn-sm">{% trans "Edit Service" %}</a>
-      <a @click="setSilenceDataset" data-service="{{service.name}}" class="btn btn-warning btn-sm">{% trans "Silence" %}</a>
-
-      <div class="btn-group btn-group-sm" role="group" aria-label="...">
-        <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          Export <span class="caret"></span>
-        </button>
-        <ul class="dropdown-menu">
-          <li role="presentation"><a href="{% url 'api:service-rules' name=service.name %}">{% trans "Export Rules" %}</a></li>
-          <li role="presentation"><a href="{% url 'api:service-targets' name=service.name %}">{% trans "Export Service" %}</a></li>
-        </ul>
-      </div>
-
-      <form method="post" action="{% url 'service-delete' service.id %}" onsubmit="return confirm('{% trans "Delete this service?" %}')" style="display: inline">
-        {% csrf_token %}
-        <button class="btn btn-danger btn-sm pull-right">{% trans "Delete Service" %}</button>
-      </form>
-    </div>
-  </div>
-
   {% if service.rule_set.count or request.site.rule_set.count %}
   <div class="panel panel-default">
     <table class="table table-bordered table-condensed">

--- a/promgen/templates/promgen/service_detail.html
+++ b/promgen/templates/promgen/service_detail.html
@@ -8,15 +8,9 @@ Promgen / Service / {{ service.name }}
 
 {% block content %}
 
-<div class="page-header" v-pre>
-  <h1>Service: {{ service.name }}</h1>
-  {% if service.owner %}
-  <p>{% trans 'Contact' %}: {{service.owner.username}}</p>
-  {% endif %}
-</div>
-
 {% breadcrumb service %}
 
+{% include "promgen/service_header.html" %}
 {% include "promgen/service_block.html" %}
 
 {% endblock %}

--- a/promgen/templates/promgen/service_header.html
+++ b/promgen/templates/promgen/service_header.html
@@ -1,8 +1,27 @@
 {% load i18n %}
 
-<h2 v-pre>
-    <a href="{% url 'service-detail' service.id %}">{{ service.name }}</a>
-    {% if service.owner %}
-    <small class="pull-right">{% trans 'Contact' %}: {{service.owner.username}}</small>
-    {% endif %}
-</h2>
+<div v-pre class="page-header promgen-flex-space-between-center">
+    <div>
+        <h2><a href="{% url 'service-detail' service.id %}">{{ service.name }}</a></h2>
+        {% if service.owner %}
+        <p>{% translate 'Contact' %}: {{service.owner.username}}</p>
+        {% endif %}
+    </div>
+</div>
+
+<div class="panel panel-default">
+    <div class="panel-body">
+        <div class="btn-group btn-group-sm" role="group" aria-label="...">
+            <button type="button" class="btn btn-primary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                {% trans "Register" %} <span class="caret"></span>
+            </button>
+            <ul class="dropdown-menu">
+                <li role="presentation"><a href="{% url 'project-new' service.id %}">{% trans "Register Project" %}</a></li>
+                <li role="presentation"><a href="{% url 'rule-new' 'service' service.id %}">{% trans "Register Rule" %}</a></li>
+                <li role="presentation"><a href="{% url 'service-notifier' service.id %}">{% trans "Register Notifier" %}</a></li>
+            </ul>
+        </div>
+
+        {% include "promgen/service_action_button_group.html" %}
+    </div>
+</div>


### PR DESCRIPTION
In the interest of consolidating some of the UI, we want to move more actions under an actions dropdown.

For Part 1, we move a number of menu options under a new service_action_button_group, and then unify our service_detail and service_list pages. In a future pull request, we will do more changes to how we display things under a service_block

This is split from #520 and focuses *ONLY* on the action button changes.


| Old Service List | New Service List |
| - | - | 
|  <img width="965" alt="old-service-list" src="https://github.com/user-attachments/assets/17159743-6924-46bf-9d13-2437d275d673"> | <img width="967" alt="new-service-list" src="https://github.com/user-attachments/assets/89145bc9-ac90-42cb-8819-5c9de71534c4"> |

| Old Service Detail | New Service Detail |
| - | - |
|  <img width="962" alt="old-service-detail" src="https://github.com/user-attachments/assets/0401703f-441f-4853-9591-03fe08652ada"> | <img width="966" alt="new-service-detail" src="https://github.com/user-attachments/assets/552d375a-d6bd-4193-b291-b85ffc481e27"> |


(I fixed the duplicate delete button but did not feel like updating the screenshots)