### PR TITLE
[IMPROVEMENT] Truncate long silence matchers

### DIFF
--- a/promgen/static/css/promgen.css
+++ b/promgen/static/css/promgen.css
@@ -69,6 +69,11 @@ a[rel]:after {
   margin-bottom: 10px;
 }
 
+.promgen-label-target > span {
+  display: inline-block;
+  vertical-align: middle;
+}
+
 .promgen-label-target:hover {
   text-decoration: none !important;
   color: #000000;
@@ -77,8 +82,16 @@ a[rel]:after {
 .promgen-label-close {
   font-size: 20px;
   margin-left: 10px;
+  margin-top: -2px;
   color: #aaaaaa;
   cursor: pointer;
+}
+
+.promgen-silence-matcher-truncate {
+  max-width: 250px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 /* service-detail */

--- a/promgen/templates/promgen/vue/silence_create_modal.html
+++ b/promgen/templates/promgen/vue/silence_create_modal.html
@@ -55,7 +55,12 @@
                 <ul class="list-inline promgen-labels-list">
                   <li v-for="(value, label) in state.labels">
                     <div class="promgen-label-target">
-                      <span>[[label]]=~[[value]]</span>
+                      <span
+                        :title="`${label}:${value}`"
+                        class="promgen-silence-matcher-truncate"
+                      >
+                        [[label]]=~[[value]]
+                      </span>
                       <span @click="removeLabel(label)" aria-hidden="true" class="promgen-label-close">&times;</span>
                     </div>
                   </li>

--- a/promgen/templates/promgen/vue/silence_list_modal.html
+++ b/promgen/templates/promgen/vue/silence_list_modal.html
@@ -31,7 +31,12 @@
                 <ul class="list-inline promgen-labels-list">
                   <li v-for="item in state.labels" :key="`${item.label}-${item.value}`">
                     <div class="promgen-label-target">
-                      <span>[[item.label]]=~[[item.value]]</span>
+                      <span
+                        :title="`${item.label}:${item.value}`"
+                        class="promgen-silence-matcher-truncate"
+                      >
+                        [[item.label]]=~[[item.value]]
+                      </span>
                       <span @click="removeFilterLabel(item.label, item.value)" aria-hidden="true" class="promgen-label-close">&times;</span>
                     </div>
                   </li>

--- a/promgen/templates/promgen/vue/silence_row.html
+++ b/promgen/templates/promgen/vue/silence_row.html
@@ -4,7 +4,12 @@
   <td class="col-xs-1">[[ time(silence.endsAt) ]]</td>
   <td class="col-xs-3 text-wrap">
     <ul class="list-inline">
-      <li v-for="matcher in silence.matchers">
+      <li
+        v-for="matcher in silence.matchers"
+        :title="`${matcher.name}:${matcher.value}`"
+        class="promgen-silence-matcher-truncate"
+        style="color: white"
+      >
         <a
           @click="$emit('matcherClick', matcher.name, matcher.value)"
           class="label"


### PR DESCRIPTION
Before:

![image](https://github.com/user-attachments/assets/d09ebca1-9c76-4694-8570-05296a7a9f5e)


After:

![image](https://github.com/user-attachments/assets/24a5b64e-d12b-415e-86d3-12fbfbc2ada7)
