### PR TITLE
Implement retrieval "Farm" APIs

### DIFF
--- a/promgen/filters.py
+++ b/promgen/filters.py
@@ -19,3 +19,8 @@ class RuleFilter(django_filters.rest_framework.FilterSet):
     name = django_filters.CharFilter(field_name="name", lookup_expr="contains")
     parent = django_filters.CharFilter(field_name="parent__name", lookup_expr="contains")
     enabled = django_filters.BooleanFilter(field_name="enabled")
+
+
+class FarmFilter(django_filters.rest_framework.FilterSet):
+    name = django_filters.CharFilter(field_name="name", lookup_expr="contains")
+    source = django_filters.CharFilter(field_name="source", lookup_expr="exact")

--- a/promgen/serializers.py
+++ b/promgen/serializers.py
@@ -102,3 +102,19 @@ class AlertRuleSerializer(serializers.ModelSerializer):
             "labels": obj.labels,
             "annotations": annotations,
         }
+
+
+class FarmSerializer(serializers.ModelSerializer):
+    url = WebLinkField()
+
+    class Meta:
+        model = models.Farm
+        fields = '__all__'
+
+
+class HostSerializer(serializers.ModelSerializer):
+    url = WebLinkField()
+
+    class Meta:
+        model = models.Host
+        exclude = ("id", "farm")

--- a/promgen/tests/examples/rest.farm.1.json
+++ b/promgen/tests/examples/rest.farm.1.json
@@ -1,0 +1,12 @@
+{
+  "id": 1,
+  "url": "http://promgen.example.com/farm/1",
+  "name": "test-farm",
+  "source": "promgen",
+  "hosts": [
+    {
+      "name": "host.example.com",
+      "url": "http://promgen.example.com/host/host.example.com"
+    }
+  ]
+}

--- a/promgen/tests/examples/rest.farm.json
+++ b/promgen/tests/examples/rest.farm.json
@@ -1,0 +1,7 @@
+[
+  {
+    "id": 1,
+    "url": "http://promgen.example.com/farm/1",
+    "name": "test-farm","source":"promgen"
+  }
+]

--- a/promgen/urls.py
+++ b/promgen/urls.py
@@ -28,6 +28,7 @@ router.register("all", rest.AllViewSet, basename="all")
 router.register("service", rest.ServiceViewSet)
 router.register("shard", rest.ShardViewSet)
 router.register("project", rest.ProjectViewSet)
+router.register("farm", rest.FarmViewSet)
 
 
 urlpatterns = [


### PR DESCRIPTION
Adding 2 APIs for retrieving Farm's data:

1. `GET /rest/farm`
Returns a JSON array of all farms in Promgen. 
_Available request params:_
- **source**: string. The returned array of farms will be of this source type. **Exact match**.
- **name**: string. The returned array of farms will have the name which contains the parameter's value. **Contains**

_Sample response:_
```
[
    {
        "id": 1,
        "url": "http://127.0.0.1:8000/farm/1",
        "name": "farm-test",
        "source": "promgen"
    },
    ...
]
```



2. `GET /rest/farm/:id`
Returns the farm matching the ID as a JSON object, including the list of hosts.

_Sample response:_
```
{
    "id": 1,
    "url": "http://127.0.0.1:8000/farm/1",
    "name": "farm-test",
    "source": "promgen",
    "hosts": [
        {
            "url": "http://127.0.0.1:8000/host/host-test.com",
            "name": "host-test.com"
        },
        ...
    ]
}
```
