### PR TITLE
Custom the save method of the Rule model to handle the annotation "rule"

### DIFF
--- a/promgen/tests/test_models.py
+++ b/promgen/tests/test_models.py
@@ -1,10 +1,12 @@
 # Copyright (c) 2020 LINE Corporation
 # These sources are released under the terms of the MIT license: see LICENSE
+from unittest import mock
 
-
+from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
 
 from promgen import models, validators
+from promgen.shortcuts import resolve_domain
 from promgen.tests import PromgenTest
 
 
@@ -34,3 +36,36 @@ class ModelTest(PromgenTest):
             validators.metricname(
                 "[[this.$el.ownerDocument.defaultView.alert(1337)]]",
             )
+
+    @mock.patch("django.dispatch.dispatcher.Signal.send")
+    def test_rule_annotation(self, mock_post):
+        # Check if annotation["rule"] is automatically set to be {domain}/rule/{id} when creating a
+        # new rule
+        rule = models.Rule(
+            name="example-rule",
+            content_type=ContentType.objects.get_for_model(models.Site),
+            object_id=1,
+            clause="up==1",
+            duration="1s"
+        )
+        rule.save()
+        self.assertEqual(resolve_domain("rule-detail", rule.pk), rule.annotations["rule"])
+
+        # Check if annotation["rule"] is automatically set to be {domain}/rule/{id} when updating an
+        # existed rule
+        rule.name = "another-example-rule"
+        rule.annotations["rule"] = "another-annotation-value"
+        rule.save()
+        self.assertEqual(resolve_domain("rule-detail", rule.pk), rule.annotations["rule"])
+
+        # Check if annotation["rule"] is still set to be {domain}/rule/{id} when trying to remove
+        # annotation["rule"]
+        rule.annotations["rule"] = None
+        rule.save()
+        self.assertEqual(resolve_domain("rule-detail", rule.pk), rule.annotations["rule"])
+
+        # Check if annotation["rule"] of new rule is automatically set to be {domain}/rule/{id}
+        # when cloning an existed rule
+        new_rule = rule.copy_to(content_type="service", object_id=2)
+        self.assertEqual(resolve_domain("rule-detail", rule.pk), rule.annotations["rule"])
+        self.assertEqual(resolve_domain("rule-detail", new_rule.pk), new_rule.annotations["rule"])


### PR DESCRIPTION
When creating or updating a rule on Promgen, the corresponding rule data on Prometheus will be given an annotation **"rule"** that is the link to that rule on Promgen. However, the annotation rule on Promgen always has the URI **"/rule/0"** because it has not been intentionally set up:

- Previously, the value of **annotation["rule"]** on Promgen was accidentally set when loading data from the [AlertRuleForm](https://github.com/line/promgen/blob/master/promgen/forms.py#L137C7-L137C20). Specifically, in the form's [clean()](https://github.com/line/promgen/blob/master/promgen/forms.py#L151) method, there is a declaration of [prometheus.check_rule()](https://github.com/line/promgen/blob/master/promgen/forms.py#L170C2-L170C39), which includes a [**serializer**](https://github.com/line/promgen/blob/master/promgen/serializers.py#L96) that automatically adds the annotation["rule"]. Since Python is _pass-by-object-reference_, annotation["rule"] of the rule will be automatically set whenever we create or update it.
- After the commit https://github.com/line/promgen/commit/276141950cfc8b899e0b1446b2f581a611f6dcbc, to handle the case of calling prometheus.check_rule() when creating a new rule, a temporary line of code setting [**rule.pk=0**](https://github.com/line/promgen/blob/master/promgen/forms.py#L162) was added. Since this is a shared form between creating and updating, the value of annotation["rule"] for **both cases** becomes **/rule/0**.
- The actual value of annotation["rule"] on Prometheus is not affected because it will be serialized again before each time it is sent to Prometheus. https://github.com/line/promgen/blob/master/promgen/signals.py#L173

-->
To ensure data is synced between Promgen and Prometheus, I customize the save method of the Rule model.
This solution will help keep the data in the database synchronized and requires minimal changes while still affecting all processes such as displaying, creating, updating, cloning, or importing rules.

**Before:**
Data displayed on Rule page after creating or updating rule:
<img width="397" alt="image" src="https://github.com/user-attachments/assets/b0dff977-78f8-45d5-aff1-a68d8803f9d3">

**After:**
Data displayed on Rule page after creating or updating rule:
<img width="485" alt="image" src="https://github.com/user-attachments/assets/be6405e6-b75f-4616-ab81-94d503de133d">
