### PR TITLE
[FIX] templates/service_detail: Show description

### DIFF
--- a/promgen/templates/promgen/service_detail.html
+++ b/promgen/templates/promgen/service_detail.html
@@ -21,6 +21,14 @@ Promgen / Service / {{ service.name }}
 
 {% breadcrumb service %}
 
+{% if service.description %}
+<div class="panel panel-default">
+  <div v-pre class="panel-body">
+    {{service.description|linebreaksbr|urlize}}
+  </div>
+</div>
+{% endif %}
+
 <ul class="nav nav-tabs mb-5" role="tablist">
   <li role="presentation" class="active"><a href="#projects" data-toggle="tab">Projects</a></li>
   <li role="presentation"><a href="#rules" data-toggle="tab">Rules</a></li>


### PR DESCRIPTION
This was removed when we changed the service detail page to use tabs. This commit brings it back.