### PR TITLE
Improve UI/UX of the global list of silence

### DIFF
--- a/promgen/static/js/promgen.vue.js
+++ b/promgen/static/js/promgen.vue.js
@@ -391,7 +391,7 @@ app.component('silence-list-modal', {
                     labels.add(matcher.name);
                 });
             });
-            return Array.from(labels);
+            return Array.from(labels).sort();
         },
         filteredValues() {
             if (!this.form.label) return [];
@@ -403,7 +403,7 @@ app.component('silence-list-modal', {
                     }
                 });
             });
-            return Array.from(values);
+            return Array.from(values).sort();
         }
     },
     methods: {

--- a/promgen/static/js/promgen.vue.js
+++ b/promgen/static/js/promgen.vue.js
@@ -368,7 +368,13 @@ app.component('silence-list-modal', {
     },
     computed: {
         activeSilences() {
-            return this.$root.activeSilences || [];
+            const silences = this.$root.activeSilences || [];
+            if (silences) {
+                for (const silence of silences) {
+                    silence.matchers.sort((a, b) => a.name.localeCompare(b.name));
+                }
+            }
+            return silences;
         },
         filteredSilences() {
             if (!this.state.labels || this.state.labels.length === 0) {

--- a/promgen/static/js/promgen.vue.js
+++ b/promgen/static/js/promgen.vue.js
@@ -386,7 +386,7 @@ app.component('silence-list-modal', {
         },
         uniqueLabels() {
             const labels = new Set();
-            this.activeSilences.forEach(silence => {
+            this.filteredSilences.forEach(silence => {
                 silence.matchers.forEach(matcher => {
                     labels.add(matcher.name);
                 });
@@ -396,7 +396,7 @@ app.component('silence-list-modal', {
         filteredValues() {
             if (!this.form.label) return [];
             const values = new Set();
-            this.activeSilences.forEach(silence => {
+            this.filteredSilences.forEach(silence => {
                 silence.matchers.forEach(matcher => {
                     if (matcher.name === this.form.label) {
                         values.add(matcher.value);

--- a/promgen/templates/promgen/vue/silence_list_modal.html
+++ b/promgen/templates/promgen/vue/silence_list_modal.html
@@ -13,7 +13,7 @@
           <div class="col-md-12">
             <div style="display: flex;align-items: center;">
               <select v-model="form.label" class="form-control" @change="updateValueOptions">
-                <option value="">Select a label</option>
+                <option value="" disabled hidden selected>Select a label</option>
                 <option value="project">project</option>
                 <option value="service">service</option>
                 <option value="" disabled>--------</option>
@@ -28,7 +28,7 @@
               </select>
               <input type="text" placeholder="=~" style="max-width: 50px; text-align: center;" class="form-control ml-2 mr-2"  disabled>
               <select v-model="form.value" class="form-control" :disabled="!form.label">
-                <option value="">Select a value</option>
+                <option value="" disabled hidden selected>Select a value</option>
                 <option v-for="value in filteredValues" :value="value">[[value]]</option>
               </select>
               <button type="button" class="btn btn-primary ml-2" @click="addFilterLabel" :disabled="!form.label || !form.value">&plus;</button>

--- a/promgen/templates/promgen/vue/silence_list_modal.html
+++ b/promgen/templates/promgen/vue/silence_list_modal.html
@@ -14,7 +14,17 @@
             <div style="display: flex;align-items: center;">
               <select v-model="form.label" class="form-control" @change="updateValueOptions">
                 <option value="">Select a label</option>
-                <option v-for="label in uniqueLabels" :value="label">[[label]]</option>
+                <option value="project">project</option>
+                <option value="service">service</option>
+                <option value="" disabled>--------</option>
+                <template v-for="label in uniqueLabels">
+                  <option
+                    v-if="!['service', 'project'].includes(label)"
+                    :value="label"
+                  >
+                    [[label]]
+                  </option>
+                </template>
               </select>
               <input type="text" placeholder="=~" style="max-width: 50px; text-align: center;" class="form-control ml-2 mr-2"  disabled>
               <select v-model="form.value" class="form-control" :disabled="!form.label">


### PR DESCRIPTION
### 1. Sort label and value dropdowns for the global silence list's filters
BEFORE:
<img width="407" alt="image" src="https://github.com/user-attachments/assets/711820ec-7d7f-4220-aeec-ec1bc108afd8" />

AFTER:
<img width="394" alt="image" src="https://github.com/user-attachments/assets/eb217a5b-4cca-4aae-a3db-262bf27e2c04" />

### 2. Update dropdown lists whenever filters are updated
BEFORE:
<img width="833" alt="image" src="https://github.com/user-attachments/assets/d2de2a13-d54f-4dfd-8759-b118463485ae" />

AFTER:
<img width="835" alt="image" src="https://github.com/user-attachments/assets/816f0a1a-ea73-4468-9186-174c71efb8d0" />

### 3. Sort matchers for the global silence list
BEFORE:
<img width="217" alt="image" src="https://github.com/user-attachments/assets/d35ac4b9-bff1-4957-90a8-5d859ea0c20b" />

AFTER:
<img width="225" alt="image" src="https://github.com/user-attachments/assets/8aa19570-5e4a-4232-95b7-efdfdd45cd83" />

### 4. Disable the placeholder messages
BEFORE:
<img width="465" alt="image" src="https://github.com/user-attachments/assets/173897e5-5d6f-4603-bcac-a51a0bcf85b6" />

AFTER:
<img width="457" alt="image" src="https://github.com/user-attachments/assets/7c800c9a-2f98-4da5-a6a6-2d5d036b7e4f" />

