### PR TITLE
[BUGFIX] Error when retrieve notifiers from a service or project

### DIFF
--- a/promgen/serializers.py
+++ b/promgen/serializers.py
@@ -54,6 +54,7 @@ class SenderSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = models.Sender
+        fields = "__all__"
 
 
 class AlertRuleList(serializers.ListSerializer):


### PR DESCRIPTION
Creating a ModelSerializer without either the 'fields' attribute or the 'exclude' attribute has been deprecated since Django REST Framework 3.3.0, and is now disallowed. It caused an internal error when calling the notifiers retrieve API. We add an explicit fields = '__all__' to the SenderSerializer serializer to resolve this issue.