### PR TITLE
Remove 'authorization' field from the retrieve Shard API

### DIFF
--- a/promgen/serializers.py
+++ b/promgen/serializers.py
@@ -21,7 +21,7 @@ class ShardSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = models.Shard
-        exclude = ("id",)
+        exclude = ("id", "authorization")
         lookup_field = "name"
 
 


### PR DESCRIPTION
For security reason, we should not return token data of to users through the retrieve Shard API.

BEFORE:
<img width="380" alt="image" src="https://github.com/user-attachments/assets/fd16d6fa-1179-4e51-a1c3-7f1893c467a6" />


AFTER:
<img width="403" alt="image" src="https://github.com/user-attachments/assets/444d36f1-6400-4e9a-b47d-7598348fdf33" />
