### PR TITLE
Release 0.68.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# v0.68.0 - 2025-03-13
+
+- [SECURITY] Remove 'authorization' field from the retrieve Shard API #576
+
 # v0.67.1 - 2025-03-04
 
 - [BUGFIX] Misleading =~ operator in silence form #570

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "promgen"
-version = "0.68.0.dev"
+version = "0.68.0"
 authors = [{ name = "LINE Corporation", email = "dl_oss_dev@linecorp.com" }]
 classifiers = [
     "Environment :: Web Environment",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "promgen"
-version = "0.68.0"
+version = "0.69.0.dev"
 authors = [{ name = "LINE Corporation", email = "dl_oss_dev@linecorp.com" }]
 classifiers = [
     "Environment :: Web Environment",


### PR DESCRIPTION
- [SECURITY] Remove 'authorization' field from the retrieve Shard API #576