### PR TITLE
Make the Farm retrieve APIs return the name of the Farm's owner

### DIFF
--- a/promgen/fixtures/testcases.yaml
+++ b/promgen/fixtures/testcases.yaml
@@ -41,6 +41,7 @@
   fields:
     name: test-farm
     source: promgen
+    owner: 1
 - model: promgen.project
   pk: 1
   fields:

--- a/promgen/serializers.py
+++ b/promgen/serializers.py
@@ -106,6 +106,7 @@ class AlertRuleSerializer(serializers.ModelSerializer):
 
 
 class FarmSerializer(serializers.ModelSerializer):
+    owner = serializers.ReadOnlyField(source="owner.username")
     url = WebLinkField()
 
     class Meta:

--- a/promgen/tests/examples/rest.farm.1.json
+++ b/promgen/tests/examples/rest.farm.1.json
@@ -3,7 +3,7 @@
   "url": "http://promgen.example.com/farm/1",
   "name": "test-farm",
   "source": "promgen",
-  "owner": null,
+  "owner": "admin",
   "hosts": [
     {
       "name": "host.example.com",

--- a/promgen/tests/examples/rest.farm.json
+++ b/promgen/tests/examples/rest.farm.json
@@ -4,6 +4,6 @@
     "url": "http://promgen.example.com/farm/1",
     "name": "test-farm",
     "source":"promgen",
-    "owner": null
+    "owner": "admin"
   }
 ]


### PR DESCRIPTION
Field 'owner' was added to the Farm model in commit 2dd4338. The owner's name should be returned through the Farm retrieve APIs, instead of the owner's primary key. This was overlooked on a previous pull request. (https://github.com/line/promgen/pull/582)

AS-IS:
<img width="347" alt="image" src="https://github.com/user-attachments/assets/f170e647-92e1-4692-8943-166838b2f363" />

TO-BE:
<img width="364" alt="image" src="https://github.com/user-attachments/assets/cb12e7b6-d28f-41c5-ac8f-9e682319c389" />
