### PR TITLE
GitHub Actions: Update Ubuntu runner to 24.04

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   docs:
     name: Run tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     strategy:
       fail-fast: false

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   docker:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4.2.2

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   build:
     name: Build Sphinx Documentation
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     strategy:
       matrix:
@@ -55,7 +55,7 @@ jobs:
       name: production
       url: ${{ steps.deployment.outputs.page_url }}
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Deploy to GitHub Pages
         id: deployment


### PR DESCRIPTION
Ubuntu 20.04 has been retired and our actions are failing with the following error message:

  This is a scheduled Ubuntu 20.04 retirement. Ubuntu 20.04 LTS runner will be
  removed on 2025-04-15. For more details, see
  https://github.com/actions/runner-images/issues/11101

  GitHub Actions has encountered an internal error when running your job.