### PR TITLE
[BUGFIX] "Home" link in the breadcrumb redirects to the "Services" page

### DIFF
--- a/promgen/templates/promgen/farm_detail.html
+++ b/promgen/templates/promgen/farm_detail.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% load i18n %}
+{% load promgen %}
 
 {% block content %}
 
@@ -12,11 +13,7 @@
   </h1>
 </div>
 
-<ol class="breadcrumb" v-pre>
-  <li><a href="{% url 'service-list' %}">Home</a></li>
-  <li><a href="{% url 'farm-list' %}">Farms</a></li>
-  <li class="active"><a href="{% url 'farm-detail' farm.id %}">{{ farm.name }}</a></li>
-</ol>
+{% breadcrumb farm %}
 
 <div class="row" v-pre>
 

--- a/promgen/templates/promgen/farm_duplicate.html
+++ b/promgen/templates/promgen/farm_duplicate.html
@@ -1,11 +1,9 @@
 {% extends "base.html" %}
+{% load promgen %}
 
 {% block content %}
 
-<ol class="breadcrumb">
-  <li><a href="{% url 'service-list' %}">Home</a></li>
-  <li class="active">Convert Farm</li>
-</ol>
+{% breadcrumb label="Convert Farm" %}
 
 <div class="panel panel-warning" v-pre>
   <div class="panel-heading">Error converting farm. Duplicate detected</div>

--- a/promgen/templates/promgen/farm_form.html
+++ b/promgen/templates/promgen/farm_form.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load promgen %}
 
 {% block content %}
 
@@ -6,12 +7,7 @@
   <h1>Project: {{ project.name }}</h1>
 </div>
 
-<ol class="breadcrumb" v-pre>
-  <li><a href="{% url 'service-list' %}">Home</a></li>
-  <li><a href="{% url 'service-detail' project.service.id %}">{{ project.service.name }}</a></li>
-  <li><a href="{% url 'project-detail' project.id %}">{{ project.name }}</a></li>
-  <li class="active">{{ view.button_label }}</li>
-</ol>
+{% breadcrumb project view.button_label %}
 
 <form method="post" v-pre>{% csrf_token %}
     {{ form.as_p }}

--- a/promgen/templates/promgen/host_404.html
+++ b/promgen/templates/promgen/host_404.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load promgen %}
 
 {% block title %}No hosts found for {{ slug }}{% endblock %}
 
@@ -7,10 +8,7 @@
   <h1>Host: {{ slug }}</h1>
 </div>
 
-<ol class="breadcrumb" v-pre>
-  <li><a href="{% url 'service-list' %}">Home</a></li>
-  <li class="active">{{ slug }}</li>
-</ol>
+{% breadcrumb label=slug %}
 
 <div class="alert alert-danger" role="alert" v-pre>
 No hosts found for {{ slug }}

--- a/promgen/templates/promgen/host_detail.html
+++ b/promgen/templates/promgen/host_detail.html
@@ -1,15 +1,13 @@
 {% extends "base.html" %}
 {% load i18n %}
+{% load promgen %}
 {% block content %}
 
 <div class="page-header" v-pre>
   <h1>Host: {{ slug }}</h1>
 </div>
 
-<ol class="breadcrumb" v-pre>
-  <li><a href="{% url 'service-list' %}">Home</a></li>
-  <li class="active">{{ slug }}</li>
-</ol>
+{% breadcrumb label=slug %}
 
 <div style="display:none" data-instance="{{slug}}" class="panel panel-danger promgen-alert">
   <div class="panel-heading">Alerts</div>

--- a/promgen/templates/promgen/host_form.html
+++ b/promgen/templates/promgen/host_form.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% load i18n %}
+{% load promgen %}
 
 {% block content %}
 
@@ -7,12 +8,7 @@
   <h1>Farm: {{ farm.name }}</h1>
 </div>
 
-<ol class="breadcrumb" v-pre>
-  <li><a href="{% url 'service-list' %}">Home</a></li>
-  <li><a href="{% url 'service-detail' project.service.id %}">{{ project.service.name }}</a></li>
-  <li><a href="{% url 'project-detail' project.id %}">{{ project.name }}</a></li>
-  <li class="active">Add hosts to {{ farm.name }}</li>
-</ol>
+{% breadcrumb project label="Add hosts to "|add:farm.name %}
 
 <form action="{% url 'hosts-add' farm.id %}" method="post" v-pre>{% csrf_token %}
   <table>

--- a/promgen/templates/promgen/host_list.html
+++ b/promgen/templates/promgen/host_list.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load promgen %}
 
 {% block content %}
 
@@ -6,10 +7,8 @@
   <h1>Hosts</h1>
 </div>
 
-<ol class="breadcrumb">
-  <li><a href="{% url 'service-list' %}">Home</a></li>
-  <li class="active">All Hosts</li>
-</ol>
+{% breadcrumb label="All Hosts" %}
+
 {% include "promgen/pagination_short.html" with page_obj=host_groups %}
 <div class="panel panel-default">
     <table class="table table-bordered table-condensed">

--- a/promgen/templates/promgen/import_form.html
+++ b/promgen/templates/promgen/import_form.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load promgen %}
 
 {% block content %}
 
@@ -6,10 +7,7 @@
   <h1>Import Configs</h1>
 </div>
 
-<ol class="breadcrumb">
-  <li><a href="{% url 'service-list' %}">Home</a></li>
-  <li class="active">Import Service</li>
-</ol>
+{% breadcrumb label="Import Service" %}
 
 <div class="panel panel-default">
   <div class="panel-heading">Import Targets</div>

--- a/promgen/templates/promgen/link_farm.html
+++ b/promgen/templates/promgen/link_farm.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load promgen %}
 
 {% block content %}
 
@@ -6,12 +7,7 @@
   <h1>Project: {{ project.name }}</h1>
 </div>
 
-<ol class="breadcrumb" v-pre>
-  <li><a href="{% url 'service-list' %}">Home</a></li>
-  <li><a href="{% url 'service-detail' project.service.id %}">{{ project.service.name }}</a></li>
-  <li><a href="{% url 'project-detail' project.id %}">{{ project.name }}</a></li>
-  <li class="active">Link Farm {{ source }}</li>
-</ol>
+{% breadcrumb project label="Link Farm "|add:source %}
 
 <div class="panel panel-default" v-pre>
   <div class="panel-heading">

--- a/promgen/templates/promgen/rule_import.html
+++ b/promgen/templates/promgen/rule_import.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load promgen %}
 
 {% block content %}
 
@@ -6,10 +7,7 @@
   <h1>Import Rules</h1>
 </div>
 
-<ol class="breadcrumb">
-  <li><a href="{% url 'service-list' %}">Home</a></li>
-  <li class="active">Import Rule</li>
-</ol>
+{% breadcrumb label="Import Rule" %}
 
 <div class="panel panel-default">
   <div class="panel-heading">Import Rules</div>

--- a/promgen/templates/promgen/rule_list.html
+++ b/promgen/templates/promgen/rule_list.html
@@ -7,10 +7,7 @@
   <h1>Rules</h1>
 </div>
 
-<ol class="breadcrumb">
-  <li><a href="{% url 'service-list' %}">Home</a></li>
-  <li class="active">List Rules</li>
-</ol>
+{% breadcrumb label="List Rules" %}
 {% include "promgen/pagination_short.html" %}
 {% regroup rule_list by content_object as grouped_rule_list %}
 

--- a/promgen/templates/promgen/search.html
+++ b/promgen/templates/promgen/search.html
@@ -1,15 +1,13 @@
 {% extends "base.html" %}
 {% load i18n %}
+{% load promgen %}
 {% block content %}
 
 <div class="page-header">
   <h1>Search</h1>
 </div>
 
-<ol class="breadcrumb">
-  <li><a href="{% url 'service-list' %}">Home</a></li>
-  <li class="active">Search</li>
-</ol>
+{% breadcrumb label="Search" %}
 
 {% include "promgen/pagination_short.html" %}
 {% if service_list %}

--- a/promgen/templates/promgen/url_form.html
+++ b/promgen/templates/promgen/url_form.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load promgen %}
 
 {% block content %}
 
@@ -6,12 +7,7 @@
   <h1 v-pre>Project: {{ project.name }}</h1>
 </div>
 
-<ol class="breadcrumb" v-pre>
-  <li><a href="{% url 'service-list' %}">Home</a></li>
-  <li><a href="{% url 'service-detail' project.service.id %}">{{ project.service.name }}</a></li>
-  <li><a href="{% url 'project-detail' project.id %}">{{ project.name }}</a></li>
-  <li class="active">Add URL to {{ farm.name }}</li>
-</ol>
+{% breadcrumb project label="Add URL" %}
 
 <form action="{% url 'url-new' project.id %}" method="post" v-pre>{% csrf_token %}
   <table>

--- a/promgen/templatetags/promgen.py
+++ b/promgen/templatetags/promgen.py
@@ -177,7 +177,7 @@ def breadcrumb(instance=None, label=None):
             yield from farm(instance)
 
     def to_tag():
-        yield '<ol class="breadcrumb">'
+        yield '<ol class="breadcrumb" v-pre>'
         for href, text in generator():
             yield format_html('<li><a href="{}">{}</a></li>', mark_safe(href), text)
         if label:

--- a/promgen/templatetags/promgen.py
+++ b/promgen/templatetags/promgen.py
@@ -155,6 +155,10 @@ def breadcrumb(instance=None, label=None):
         if obj.content_type.model == "project":
             yield from project(obj.content_object)
 
+    def farm(obj):
+        yield reverse("farm-list"), _("Farms")
+        yield obj.get_absolute_url(), obj.name
+
     def generator():
         yield reverse("home"), _("Home")
         if isinstance(instance, models.Sender):
@@ -169,6 +173,8 @@ def breadcrumb(instance=None, label=None):
             yield from rule(instance)
         if isinstance(instance, models.Alert):
             yield from alert(instance)
+        if isinstance(instance, models.Farm):
+            yield from farm(instance)
 
     def to_tag():
         yield '<ol class="breadcrumb">'


### PR DESCRIPTION
On some pages of Promgen, the Home link in the breadcrumb is redirected to the Services page instead of the Home page. We have fixed all these errors by using the "breadcrumb" template tag. We also made some improvements to this template tag to handle the Farm object and add the "v-pre" tag by default.