### PR TITLE
Use DRF's APIView for AlertReceiver API

### DIFF
--- a/promgen/rest.py
+++ b/promgen/rest.py
@@ -3,15 +3,17 @@
 
 from django.core.serializers import get_serializer
 from django.http import HttpResponse
-from django.views.generic import View
 from rest_framework import permissions, viewsets
 from rest_framework.decorators import action
 from rest_framework.response import Response
+from rest_framework.views import APIView
 
 from promgen import filters, models, prometheus, renderers, serializers, tasks
 
 
-class AlertReceiver(View):
+class AlertReceiver(APIView):
+    permission_classes = [permissions.AllowAny]
+
     def post(self, request, *args, **kwargs):
         # Normally it would be more 'correct' to check our 'alert_blacklist' here and avoid
         # writing to the database, but to keep the alert ingestion queue as simple as possible


### PR DESCRIPTION
Django's View class is designed for building traditional web applications that render HTML templates. On the other hand, APIView is part of Django REST Framework and is specifically designed for building robust RESTful APIs. Therefore, we have transitioned from using Django's View class to Django REST Framework's APIView for the AlertReceiver API. This change allows us to implement advanced features such as authentication and permissions in the future.
This update does not affect the current behavior of the AlertReceiver API.