### PR TITLE
Trim whitespaces of search input

### DIFF
--- a/promgen/views.py
+++ b/promgen/views.py
@@ -1211,6 +1211,9 @@ class Search(LoginRequiredMixin, View):
         # To avoid searching all object, remove empty search parameters
         # from the request query string.
         query_dict = request.GET.copy()
+        for key, value in query_dict.items():
+            query_dict[key] = value.strip() # Trim whitespaces of search input
+
         empty_value_parameters = [key for key, value in query_dict.lists() if not any(value)]
         for empty_value_parameter in empty_value_parameters:
             del query_dict[empty_value_parameter]


### PR DESCRIPTION
Sometimes, when users want to search for a keyword, it may accidentally include leading or trailing spaces because the user copied the keyword from elsewhere or due to a typing error. This results in empty search results because nothing matches the input. Therefore, before starting the search, we clean up the user's input by trimming the spaces at the beginning and at the end of the input string.