### PR TITLE
Rename some buttons

### DIFF
--- a/promgen/templates/promgen/project_detail_configuration.html
+++ b/promgen/templates/promgen/project_detail_configuration.html
@@ -26,8 +26,8 @@
         {% trans "Change History" %} <span class="caret"></span>
       </button>
       <ul class="dropdown-menu">
-        <li role="presentation"><a href="{% urlqs 'audit-list' project=project.id  %}">{% trans "Edit History" %}</a></li>
-        <li role="presentation"><a href="{% urlqs 'alert-list' project=project.name %}">{% trans "Alert History" %}</a></li>
+        <li role="presentation"><a href="{% urlqs 'audit-list' project=project.id  %}">{% trans "View Edit History" %}</a></li>
+        <li role="presentation"><a href="{% urlqs 'alert-list' project=project.name %}">{% trans "View Alert History" %}</a></li>
       </ul>
     </div>
 

--- a/promgen/templates/promgen/rule_detail.html
+++ b/promgen/templates/promgen/rule_detail.html
@@ -38,7 +38,7 @@ Promgen / Rule / {{ rule.name }}
     </div>
     <div class="panel-footer">
         <a href="{% url 'rule-edit' rule.pk %}" class="btn btn-warning btn-sm">{% trans "Edit Rule" %}</a>
-        <a href="{% urlqs 'alert-list' alertname=rule.name %}" class="btn btn-info btn-sm">{% trans "Alert History" %}</a>
+        <a href="{% urlqs 'alert-list' alertname=rule.name %}" class="btn btn-info btn-sm">{% trans "View Alert History" %}</a>
     </div>
 </div>
 

--- a/promgen/templates/promgen/rule_update.html
+++ b/promgen/templates/promgen/rule_update.html
@@ -92,8 +92,8 @@ Promgen / Rule / {{ rule.name }}
   <div class="panel panel-primary">
     <div class="panel-body">
       <button class="btn btn-primary">Save Rule</button>
-      <a href="{% urlqs 'audit-list' rule=rule.id %}" class="btn btn-info">{% trans "Edit History" %}</a>
-      <a href="{% urlqs 'alert-list' alertname=rule.name %}" class="btn btn-info">{% trans "Alert History" %}</a>
+      <a href="{% urlqs 'audit-list' rule=rule.id %}" class="btn btn-info">{% trans "View Edit History" %}</a>
+      <a href="{% urlqs 'alert-list' alertname=rule.name %}" class="btn btn-info">{% trans "View Alert History" %}</a>
     </div>
   </div>
 </form>

--- a/promgen/templates/promgen/service_action_button_group.html
+++ b/promgen/templates/promgen/service_action_button_group.html
@@ -18,8 +18,8 @@
 
       <hr>
 
-      <li role="presentation"><a href="{% urlqs 'audit-list' service=service.id %}">{% translate "Edit History" %}</a></li>
-      <li role="presentation"><a href="{% urlqs 'alert-list' service=service.name %}">{% translate "Alert History" %}</a></li>
+      <li role="presentation"><a href="{% urlqs 'audit-list' service=service.id %}">{% translate "View Edit History" %}</a></li>
+      <li role="presentation"><a href="{% urlqs 'alert-list' service=service.name %}">{% translate "View Alert History" %}</a></li>
 
       <hr>
 


### PR DESCRIPTION
There are some buttons that represent actions, but the button names are displayed as nouns. This can be ambiguous for users. For example, a button that allows users to view the edit history of an object is named "Edit History," but at first glance, users might misunderstand it as a button related to editing some historical information. This is especially true when the button is placed in a group of "Actions" buttons alongside other buttons that indicate actions, such as "Export", "Subscribe" and "Delete."

Therefore, we have changed the names of some buttons to clarify their meanings.
- Edit History -> View Edit History
- Alert History -> View Alert History

AS-IS:
<img width="306" alt="image" src="https://github.com/user-attachments/assets/a139be04-a340-464c-90be-d2ed6357ee57" />

TO-BE:
<img width="266" alt="image" src="https://github.com/user-attachments/assets/bae7fa76-d87f-4cff-989c-fca36bb48c0e" />
