### PR TITLE
Set owner when adding external farms

### DIFF
--- a/promgen/views.py
+++ b/promgen/views.py
@@ -635,6 +635,9 @@ class FarmLink(LoginRequiredMixin, View):
             logger.info("Importing %s from %s", farm.name, source)
             farm.refresh()
             messages.info(request, "Refreshed hosts")
+            if source != discovery.FARM_DEFAULT:
+                farm.owner = self.request.user
+                farm.save()
         project.farm = farm
         project.save()
         return HttpResponseRedirect(reverse("project-detail", args=[project.id]))


### PR DESCRIPTION
Promgen's Farm system is a pluggable system that allows people to write their own plugins. The default plugin is what allows creating local farms, also known as "promgen" farms, and is shipped with Promgen. But other plugins can be added to discover external farms, and link them to projects. After linking them to a project, if that external farm was not already in Promgen's data base, it will be added.
This commit ensures that when such external farms are added to the data base they have an owner set.
Those external farms are not editable, so the owner fields won't be used to decide who can modify the farm. However, since we are planning to enforce the owner fields to not be null, we need to ensure the owner field is set.