### PR TITLE
Preventing the browser from caching promgen.vue.js file

### DIFF
--- a/promgen/templates/base.html
+++ b/promgen/templates/base.html
@@ -64,7 +64,7 @@
   </script>
   <script src="{% static 'js/promgen.js' %}"></script>
   <script src="{% static 'js/mixins.vue.js' %}"></script>
-  <script src="{% static 'js/promgen.vue.js' %}"></script>
+  <script src="{% static 'js/promgen.vue.js' %}?v=1"></script>
   {% block javascript %}{% endblock %}
 
   <datalist style="display:none" id="common.labels">


### PR DESCRIPTION
We added a version number as a query string to the promgen.vue.js file URL to prevent the user's browser from caching it. In the future, this version number will be manually increased when we modify the promgen.vue.js file. This ensures that users always receive the latest version of the JavaScript file every time we change it.