### PR TITLE
Improve UI for Farm Register page

### DIFF
--- a/promgen/forms.py
+++ b/promgen/forms.py
@@ -254,3 +254,22 @@ class HostForm(forms.Form):
         if not hosts:
             raise ValidationError("No valid hosts")
         self.cleaned_data["hosts"] = list(hosts)
+
+
+class FarmRegisterForm(forms.ModelForm):
+    hosts = forms.CharField(widget=forms.Textarea)
+
+    class Meta:
+        model = models.Farm
+        exclude = ["source"]
+
+    def clean_hosts(self):
+        hosts = set()
+        for hostname in re.split(r"[,\s]+", self.cleaned_data["hosts"]):
+            if hostname == "":
+                continue
+            validators.hostname(hostname)
+            hosts.add(hostname)
+        if not hosts:
+            raise ValidationError("No valid hosts")
+        return list(hosts)

--- a/promgen/templates/promgen/farm_register.html
+++ b/promgen/templates/promgen/farm_register.html
@@ -14,10 +14,6 @@
     <table class="table">
       {{ form.as_table }}
     </table>
-    <hr>
-    <table>
-    {{ host_form.as_table }}
-    </table>
     <div class="panel-footer">
       <button class="btn btn-primary">{{ view.button_label }}</button>
     </div>

--- a/promgen/views.py
+++ b/promgen/views.py
@@ -896,25 +896,18 @@ class FarmRegister(LoginRequiredMixin, FormView, mixins.ProjectMixin):
     model = models.Farm
     button_label = _("Register Farm")
     template_name = "promgen/farm_register.html"
-    form_class = forms.FarmForm
-
-    def get_context_data(self, **kwargs):
-        context = super().get_context_data(**kwargs)
-        context["host_form"] = kwargs.get("host_form", forms.HostForm())
-        return context
+    form_class = forms.FarmRegisterForm
 
     def form_valid(self, form):
         project = get_object_or_404(models.Project, id=self.kwargs["pk"])
-        host_form = forms.HostForm(data={"hosts": self.request.POST["hosts"]})
-        if not host_form.is_valid():
-            return self.render_to_response(self.get_context_data(form=form, host_form=host_form))
 
-        hostnames = set()
-        for hostname in host_form.cleaned_data["hosts"]:
-            hostnames.add(hostname)
+        farm, _ = models.Farm.objects.get_or_create(
+            source=discovery.FARM_DEFAULT,
+            name=form.cleaned_data["name"],
+            owner=form.cleaned_data["owner"],
+        )
 
-        farm, _ = models.Farm.objects.get_or_create(source=discovery.FARM_DEFAULT, **form.clean())
-        for hostname in hostnames:
+        for hostname in form.cleaned_data["hosts"]:
             host, created = models.Host.objects.get_or_create(name=hostname, farm_id=farm.id)
             if created:
                 logger.debug("Added %s to %s", host.name, farm.name)


### PR DESCRIPTION
We made a few changes to the FarmRegister view class and its template to improve the UI of the Farm Register page. The farm_register.html included two tables from FarmForm and HostForm, which caused many display issues. Therefore, we created a new form named FarmRegisterForm that contains all the fields from both forms to resolve all these issues and ensure the template is consistent with other Promgen's forms.

AS-IS:
<img width="1218" alt="image" src="https://github.com/user-attachments/assets/3ea1fa7a-e2cd-4ac1-8b3d-74ec270921bc" />

TO-BE:
<img width="1216" alt="image" src="https://github.com/user-attachments/assets/7756844c-e9a9-483b-a8b6-62079835021d" />
