### PR TITLE
Fix UI quirks in the Farm Register page

### DIFF
--- a/promgen/templates/promgen/farm_register.html
+++ b/promgen/templates/promgen/farm_register.html
@@ -13,10 +13,7 @@
   <form action="" method="post">{% csrf_token %}
     <table class="table">
       {{ form.as_table }}
-    </table>
-    <hr>
-    <table>
-    {{ host_form.as_table }}
+      {{ host_form.as_table }}
     </table>
     <div class="panel-footer">
       <button class="btn btn-primary">{{ view.button_label }}</button>


### PR DESCRIPTION
There was a disorganized arrangement of fields in the Farm Register form. There is a gap in the row containing the "owner" label. Additionally, the row containing the "hosts" label and textarea is misaligned. Therefore, we placed all the fields in the same table so they can be automatically aligned properly.

AS-IS:
<img width="1176" alt="image" src="https://github.com/user-attachments/assets/d3b2dd07-7596-4f96-8b00-8b6476c4aad8" />


TO-BE:
<img width="1206" alt="image" src="https://github.com/user-attachments/assets/bc3bbd9d-b32d-4f1b-b01f-080f77077a49" />
