### PR TITLE
Align the form field with its label

### DIFF
--- a/promgen/templates/django/forms/table.html
+++ b/promgen/templates/django/forms/table.html
@@ -1,0 +1,29 @@
+{% if errors %}
+  <tr>
+    <td colspan="2">
+      {{ errors }}
+      {% if not fields %}
+        {% for field in hidden_fields %}{{ field }}{% endfor %}
+      {% endif %}
+    </td>
+  </tr>
+{% endif %}
+{% for field, errors in fields %}
+  <tr{% with classes=field.css_classes %}{% if classes %} class="{{ classes }}"{% endif %}{% endwith %}>
+    <th style="width: 0; min-width: fit-content; white-space: nowrap;">{% if field.label %}{{ field.label_tag }}{% endif %}</th>
+    <td>
+      {{ errors }}
+      {{ field }}
+      {% if field.help_text %}
+        <br>
+        <span class="helptext">{{ field.help_text|safe }}</span>
+      {% endif %}
+      {% if forloop.last %}
+        {% for field in hidden_fields %}{{ field }}{% endfor %}
+      {% endif %}
+    </td>
+  </tr>
+{% endfor %}
+{% if not fields and not errors %}
+  {% for field in hidden_fields %}{{ field }}{% endfor %}
+{% endif %}


### PR DESCRIPTION
The extra white space between the label and the form field is not normal. We fixed it by overriding the Django's template form/table.html then styling the <th> tag. This solution ensures that the change only affects UIs that use the function form.as_table.

ref: https://github.com/django/django/blob/stable/4.2.x/django/forms/templates/django/forms/table.html