### PR TITLE
global_messages: show the error messages

### DIFF
--- a/promgen/templates/promgen/global_messages.html
+++ b/promgen/templates/promgen/global_messages.html
@@ -1,5 +1,17 @@
 {% for message in messages %}
-<div class="alert {% if message.tags %}alert-{{ message.tags }}{% endif %}" role="alert">
+<div
+    class="
+        alert
+        {% if message.tags %}
+            {% if message.tags == 'error' %}
+            alert-danger
+            {% else %}
+            alert-{{ message.tags }}
+            {% endif %}
+        {% endif %}
+    "
+     role="alert"
+>
     <button type="button" class="close" data-dismiss="alert">
         <span aria-hidden="true">&times;</span>
     </button>


### PR DESCRIPTION
The alert class of global messages depends on the message's tag. However, there is no alert-error class in Bootstrap, while the ERROR tag exists in Django. This causes an awkward display for messages with the ERROR tag.
Therefore, we have used the alert-danger class for the ERROR tag.

Example:
```
from django.contrib import messages
messages.error(request, _("Error happened!"))
```

AS-IS:
<img width="1197" alt="image" src="https://github.com/user-attachments/assets/55936ee7-e219-46a2-acce-7824dce2d0c9" />

TO-BE:
<img width="1187" alt="image" src="https://github.com/user-attachments/assets/b372ef1a-8b29-4f76-9531-2fccb9bb11c1" />
