### PR TITLE
Fix the breadcrumb of the Service Update page

### DIFF
--- a/promgen/templates/promgen/service_form.html
+++ b/promgen/templates/promgen/service_form.html
@@ -6,7 +6,7 @@
   <h1>{{ view.button_label }}</h1>
 </div>
 
-{% breadcrumb label=view.button_label %}
+{% breadcrumb service label=view.button_label %}
 
 {% if service %}
 <div class="alert alert-danger" role="alert">


### PR DESCRIPTION
Add the missing service links in the breadcrumb of the Service Update page.

AS-IS:
<img width="551" alt="image" src="https://github.com/user-attachments/assets/3d9c501f-14bb-4511-8434-86cd3ea062ac" />


TO-BE:
<img width="498" alt="image" src="https://github.com/user-attachments/assets/91859e32-515c-4a22-8ffd-f17480ae6dfc" />
