### PR TITLE
Fix shard unchecked when updating a project with an invalid form

### DIFF
--- a/promgen/templates/promgen/project_form.html
+++ b/promgen/templates/promgen/project_form.html
@@ -83,7 +83,7 @@
         <th v-pre>{{shard.name}}</th>
         <th v-pre>{{shard.url|urlize}}</th>
         <td>
-          <input type="radio" name="shard" value="{{shard.id}}" {% if shard.id == form.shard.value %}checked{% elif shard.enabled is False %}disabled{% endif %}>
+          <input type="radio" name="shard" value="{{shard.id}}" {% if shard.id == project.shard_id %}checked{% elif shard.enabled is False %}disabled{% endif %}>
         </td>
         <td>
           <data-source-usage class="label" shard="{{shard.name}}" metric="samples" max="{{shard.samples}}"></data-source-usage>


### PR DESCRIPTION
When you attempt to update the project again after a previous unsuccessful update, all radio buttons in the shard list become unchecked, even though at least one shard should be checked. This causes inconvenience for users who have to manually select a shard again. We have fixed this issue.