### PR TITLE
Fix empty row when registering a new project

### DIFF
--- a/promgen/templates/promgen/project_form.html
+++ b/promgen/templates/promgen/project_form.html
@@ -45,6 +45,7 @@
           {{form.owner}}
         </td>
       </tr>
+      {% if project.pk %}
       <tr>
         <th>{{form.service.label}}</th>
         <td>
@@ -52,6 +53,7 @@
           {{form.service}}
         </td>
       </tr>
+      {% endif %}
     </table>
   </div>
   {% include 'promgen/error_block.html' with warning=form.shard.errors only %}


### PR DESCRIPTION
We are using the same form for registering and updating a project. Therefore, there is an empty row at the end of the form when registering a new project because that row is only for updating the service of the project. As a result, we have hidden this row when registering a new project.

AS-IS:
<img width="1166" alt="image" src="https://github.com/user-attachments/assets/167b0e06-8ec5-4a91-afc9-fee9fb6d6f41" />


TO-BE:
<img width="1161" alt="image" src="https://github.com/user-attachments/assets/c1bb35d1-270a-46c8-bea5-a81ff6777f32" />
