### PR TITLE
Not provide query results when testing Rule

### DIFF
--- a/promgen/templates/promgen/ajax_clause_check.html
+++ b/promgen/templates/promgen/ajax_clause_check.html
@@ -4,29 +4,14 @@
   <div class="panel-heading">Query Result</div>
   <div class="panel-body">
   <p>Query Duration: {{ duration }}</p>
-  <p><code>{{ query }}</code></p>
-{% if collapse %}
-<a class="btn btn-success btn-sm" role="button" data-toggle="collapse" href="#prometheus-query-results" aria-expanded="false" aria-controls="collapseExample">
-  Show {{ data.result|length }} Results
-</a>
-{% endif %}
+  <h3>
+    {% if firing %}
+    <span class="label label-danger">Firing</span>
+    {% else %}
+    <span class="label label-default">Not firing</span>
+    {% endif %}
+  </h3>
 </div>
-{% if data.result %}
-    <table id="prometheus-query-results" class="table table-condensed table-scroll {% if collapse %}collapse{% endif %}">
-      <tr class="{{ severity }}">
-        <th>Timestamp</th>
-        <th>Value</th>
-        <th>Metric</th>
-      </tr>
-{% for row in data.result %}
-      <tr>
-        <td>{{ row.value.0 | strftime:"%Y-%m-%d %H:%M" }}</td>
-        <td>{{ row.value.1 }}</td>
-        <td>{{ row.metric }}</td>
-      </tr>
-{% endfor %}
-    </table>
-{% endif %}
 
 {% if errors %}
     <table class="table table-condensed">

--- a/promgen/views.py
+++ b/promgen/views.py
@@ -1421,14 +1421,8 @@ class RuleTest(LoginRequiredMixin, View):
         # TODO: This could be more robust, but for now this ensures failed queries
         # without a 'data' field get processed
         metrics = result.get("data", {}).setdefault("result", [])
-        result["collapse"] = len(metrics) > 5
+        result["firing"] = len(metrics) > 0
         errors = result.setdefault("errors", {})
-
-        if len(metrics) == 0:
-            errors["no_results"] = (
-                "No results. "
-                "You may need to temporarily remove conditional checks (> < ==) to verify."
-            )
 
         for row in metrics:
             if "service" not in row["metric"] and "project" not in row["metric"]:


### PR DESCRIPTION
From the Rule's edit page, users can write any query and execute with the test button. After that, the results are presented on the screen. The query is executed on all data sources, and for that Promgen provides the basic auth credentials configured in for each data source. This capability led to a potential security issue where users can run any query anonymously.

Therefore, we want to stop providing the query results to the user, and instead, just say if the rule would fire or not.

**Not firing:**
AS-IS:
![image](https://github.com/user-attachments/assets/6df8bc12-a58a-4d70-a1d2-04cad15a1302)
TO-BE:
<img width="605" alt="image" src="https://github.com/user-attachments/assets/303bd683-967f-4695-b846-5209eb79b78e" />

**Firing:**
AS-IS:
![image](https://github.com/user-attachments/assets/d300c306-eb7a-48ce-b857-1a0b51916310)
TO-BE:
![image](https://github.com/user-attachments/assets/1efd4189-99d4-4bc3-9ff0-b29dec8ad020)


