### PR TITLE
Make notifier's filters not editable if 'show_edit' is false

### DIFF
--- a/promgen/templates/promgen/sender_row.html
+++ b/promgen/templates/promgen/sender_row.html
@@ -4,18 +4,26 @@
     <td class="col-xs-5" style="word-break: break-all;" v-pre>{{ notifier.show_value }}</td>
     <td class="col-xs-2">
         {% for f in notifier.filter_set.all %}
-        <form method="post" action="{% url 'notifier-edit' notifier.id %}" onsubmit="return confirm('Delete this filter?')" style="display: inline">
-            {% csrf_token %}
-            <input name="next" type="hidden" value="{{ request.get_full_path }}" />
-            <input name="filter.pk" value="{{f.id}}" type="hidden" />
-            <button class="label label-primary" style="display: inline-block;" v-pre>
+            {% if show_edit %}
+            <form method="post" action="{% url 'notifier-edit' notifier.id %}" onsubmit="return confirm('Delete this filter?')" style="display: inline">
+                {% csrf_token %}
+                <input name="next" type="hidden" value="{{ request.get_full_path }}" />
+                <input name="filter.pk" value="{{f.id}}" type="hidden" />
+                <button class="label label-primary" style="display: inline-block;" v-pre>
+                    {{f.name}}:{{f.value}}
+                    <span class="glyphicon glyphicon-remove" aria-hidden="true"></span>
+                </button>
+            </form>
+            {% else %}
+            <span class="label label-primary" style="display: inline-block;">
                 {{f.name}}:{{f.value}}
-                <span class="glyphicon glyphicon-remove" aria-hidden="true"></span>
-            </button>
-        </form>
+            </span>
+            {% endif %}
         {% endfor %}
 
+        {% if show_edit %}
         <button class="btn btn-primary btn-xs" data-toggle="collapse" data-target="#notifierLabel{{notifier.id}}">+</button>
+        {% endif %}
         <div class="collapse" id="notifierLabel{{notifier.id}}">
             <form method="post" action="{% url 'notifier-edit' notifier.id %}" style="display: inline">
                 {% csrf_token %}


### PR DESCRIPTION
Currently, when displaying the notifier list, the Actions column will not be shown if show_edit is false. However, the filter column is still displayed along with the Add and Remove buttons when show_edit is false. For instance, when we display the Service notifiers from the Project detail page, the Action column is hidden by using the show_edit variable. However, even if the Actions column is hidden because the users are not supposed to edit those notifiers, they are still able to add filters to it, which is an edit action on the notifier.
We have changed it to only display the filters as labels and not show any actionable buttons so that the users are not supposed to add, edit or remove filters of a notifier if the value of 'show_edit' is false.


AS-IS:
<img width="576" alt="image" src="https://github.com/user-attachments/assets/fabf9663-d035-487b-93a5-95b858c6000b" />


TO-BE:
<img width="582" alt="image" src="https://github.com/user-attachments/assets/73b93c38-3ee5-474a-a959-f4e0a485a840" />
