### PR TITLE
Move buttons to Rule Detail page from Rule Update page

### DIFF
--- a/promgen/templates/promgen/rule_action_button_group.html
+++ b/promgen/templates/promgen/rule_action_button_group.html
@@ -1,0 +1,43 @@
+{% load i18n %}
+{% load promgen %}
+
+<div style="display: inline-block;" class="service-action-button-group">
+  <div class="btn-group btn-group-sm" role="group" aria-label="...">
+    <button
+      type="button"
+      class="btn btn-default dropdown-toggle"
+      data-toggle="dropdown"
+      aria-haspopup="true"
+      aria-expanded="false"
+    >
+      {% translate "Actions" %} <span class="caret"></span>
+    </button>
+    <ul class="dropdown-menu">
+      <li role="presentation">
+        <a href="{% urlqs 'audit-list' rule=rule.id %}">
+          {% trans "View Edit History" %}
+        </a>
+      </li>
+      <li role="presentation">
+        <a href="{% urlqs 'alert-list' alertname=rule.name %}" >
+          {% trans "View Alert History" %}
+        </a>
+      </li>
+      <hr />
+      <li role="presentation">
+        <form
+          method="post"
+          action="{% url 'rule-delete' rule.id %}"
+          onsubmit="return confirm('{% trans 'Delete this Rule?' %}')"
+          style="display: inline"
+        >
+          {% csrf_token %}
+          <button type="submit" style="color:#d9534f;">{% trans "Delete Rule" %}</button>
+        </form>
+      </li>
+    </ul>
+  </div>
+
+  <a href="{% url 'rule-edit' rule.pk %}" class="btn btn-warning btn-sm">{% trans "Edit Rule" %}</a>
+
+</div>

--- a/promgen/templates/promgen/rule_detail.html
+++ b/promgen/templates/promgen/rule_detail.html
@@ -8,8 +8,11 @@ Promgen / Rule / {{ rule.name }}
 {% endblock %}
 
 {% block content %}
-<div class="page-header" v-pre>
+<div class="page-header promgen-flex-space-between-center" v-pre>
+  <div>
     <h1>Rule: {{ rule.name }}</h1>
+  </div>
+  {% include "promgen/rule_action_button_group.html" %}
 </div>
 
 {% breadcrumb rule  %}
@@ -35,10 +38,6 @@ Promgen / Rule / {{ rule.name }}
         </div>
 {% endif %}
         <pre v-pre>{{rule|rule_dict|pretty_yaml}}</pre>
-    </div>
-    <div class="panel-footer">
-        <a href="{% url 'rule-edit' rule.pk %}" class="btn btn-warning btn-sm">{% trans "Edit Rule" %}</a>
-        <a href="{% urlqs 'alert-list' alertname=rule.name %}" class="btn btn-info btn-sm">{% trans "View Alert History" %}</a>
     </div>
 </div>
 

--- a/promgen/templates/promgen/rule_update.html
+++ b/promgen/templates/promgen/rule_update.html
@@ -90,21 +90,10 @@ Promgen / Rule / {{ rule.name }}
   {% endif %}
 
   <div class="panel panel-primary">
-    <div class="panel-body">
+    <div class="panel-footer">
       <button class="btn btn-primary">Save Rule</button>
-      <a href="{% urlqs 'audit-list' rule=rule.id %}" class="btn btn-info">{% trans "View Edit History" %}</a>
-      <a href="{% urlqs 'alert-list' alertname=rule.name %}" class="btn btn-info">{% trans "View Alert History" %}</a>
     </div>
   </div>
 </form>
-
-<div class="panel panel-danger">
-  <div class="panel-body">
-    <form method="post" action="{% url 'rule-delete' rule.id %}" onsubmit="return confirm('{% trans " Delete this Rule?" %}')" style="display: inline">
-      {% csrf_token %}
-      <button class="btn btn-danger">{% trans "Delete Rule" %}</button>
-    </form>
-  </div>
-</div>
 
 {% endblock %}


### PR DESCRIPTION
We moved the buttons View Edit History, View Alert History, and Delete Rule from the Rule Update page to the Rule Detail age to make it more convenient for users to use these features.

### AS-IS:
**Rule Update page**
<img width="911" alt="image" src="https://github.com/user-attachments/assets/0b7fc54a-22f7-4b5b-bf2e-3e273f49aefb" />

**Rule Detail page**
<img width="1206" alt="image" src="https://github.com/user-attachments/assets/206e4136-a78b-4e45-9ef6-3238e412f895" />


### TO-BE:
**Rule Update page**
<img width="707" alt="image" src="https://github.com/user-attachments/assets/fa0e0cc4-9f52-41a8-8461-af423958a044" />

**Rule Detail page**
<img width="1208" alt="image" src="https://github.com/user-attachments/assets/d9c8739f-b6ef-4385-ab72-a726171cfcbb" />
