### PR TITLE
Fix missing opening tag of the 'div' tag

### DIFF
--- a/promgen/templates/promgen/project_detail_notifiers.html
+++ b/promgen/templates/promgen/project_detail_notifiers.html
@@ -9,12 +9,13 @@
 <div class="panel panel-default">
   {% include "promgen/notifier_block.html" with object=project show_edit=1 %}
 </div>
-{% if project.service.notifiers.count %}
+<div>
+  {% if project.service.notifiers.count %}
   <a class="btn btn-default btn-xs" role="button" data-toggle="collapse"
      href="#show-service-senders" aria-expanded="false" aria-controls="collapseExample"
   >
     Show Service Notifiers ({{project.service.notifiers.count}})
   </a>
   {% include "promgen/notifier_block.html" with object=project.service collapse="show-service-senders" %}
-{% endif %}
+  {% endif %}
 </div>


### PR DESCRIPTION
There is a 'div' tag missing an opening tag in the file project_detail_notifiers.html. Although it is not causing any issues at the moment, it may lead to UI display errors in the future. We have added the opening tag for this 'div' tag.