### PR TITLE
Add Edit button when showing the rule list

### DIFF
--- a/promgen/templates/promgen/rule_block.html
+++ b/promgen/templates/promgen/rule_block.html
@@ -39,6 +39,7 @@
   </td>
   {% else %}
   <td>
+    <a href="{% url 'rule-edit' rule.pk %}" class="btn btn-warning btn-xs">{% trans "Edit" %}</a>
     <form method="post" action="{% url 'rule-delete' rule.id %}" onsubmit="return confirm('{% trans "Delete this Rule?" %}')" style="display: inline">
       {% csrf_token %}
       <button class="btn btn-danger btn-xs">{% trans "Delete" %}</button>

--- a/promgen/templates/promgen/rule_header.html
+++ b/promgen/templates/promgen/rule_header.html
@@ -1,6 +1,6 @@
 <tr>
     <th class="col-xs-2">Rule</th>
-    <th class="col-md-7">Clause</th>
+    <th class="col-md-6">Clause</th>
     <th class="col-xs-1">Duration</th>
     <th class="col-xs-1">Toggle</th>
     <th class="col-xs-1">Action</th>


### PR DESCRIPTION
We added an Edit button to the Actions column when displaying the rule list to make it easier for users to edit a Rule from other pages.

AS-IS:
<img width="242" height="262" alt="image" src="https://github.com/user-attachments/assets/5a2b5310-4351-498d-90a3-4d670cdc69b4" />


TO-BE:
<img width="230" height="233" alt="image" src="https://github.com/user-attachments/assets/80b12994-6830-4a9a-a14c-29ed5a90c3d1" />
