### PR TITLE
Fix the bug that overrides AUTHENTICATION_BACKENDS not work

### DIFF
--- a/promgen/settings.py
+++ b/promgen/settings.py
@@ -217,14 +217,13 @@ try:
 except ImportError:
     MIDDLEWARE.remove("debug_toolbar.middleware.DebugToolbarMiddleware")
 
-
-# Load overrides from PROMGEN to replace Django settings
-for k, v in PROMGEN.pop("django", {}).items():
-    globals()[k] = v
-
 DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
 
 AUTHENTICATION_BACKENDS = (
     "django.contrib.auth.backends.ModelBackend",
     "guardian.backends.ObjectPermissionBackend",
 )
+
+# Load overrides from PROMGEN to replace Django settings
+for k, v in PROMGEN.pop("django", {}).items():
+    globals()[k] = v


### PR DESCRIPTION
We fixed a bug that AUTHENTICATION_BACKENDS setting from PROMGEN was not replaced Django settings. Loading overrides from PROMGEN to replace Django settings should always be at the end of the settings.py file. Therefore, we changed the location of the AUTHENTICATION_BACKENDS setting.