### PR TITLE
Support change member's role on UI

### DIFF
--- a/promgen/templates/promgen/permission_row.html
+++ b/promgen/templates/promgen/permission_row.html
@@ -22,6 +22,7 @@
     {% endfor %}
   </td>
   <td class="col-xs-3" style="word-break: break-all" v-pre>
+    {% if user.username != object.owner.username %}
     <form
       method="post"
       action="{% url 'permission-delete' %}"
@@ -48,5 +49,6 @@
       </div>
       {% endif %}
     </form>
+    {% endif %}
   </td>
 </tr>

--- a/promgen/templates/promgen/permission_row.html
+++ b/promgen/templates/promgen/permission_row.html
@@ -20,6 +20,23 @@
       {{ perm|upper }}
     </span>
     {% endfor %}
+
+    {% if user.username != object.owner.username %}
+    <button style="background:none" class="btn btn-xs" data-toggle="collapse" data-target="#user{{user.id}}">
+      <span class="glyphicon glyphicon-cog" aria-hidden="true"></span>
+    </button>
+    <div class="collapse" id="user{{user.id}}">
+      <form method="post" action="{% url 'permission-assign' %}" style="display: inline">
+        {% csrf_token %}
+        <input name="next" type="hidden" value="{{ request.get_full_path }}#members" />
+        <input name="model" type="hidden" value="{{ object | klass }}" />
+        <input name="id" type="hidden" value="{{ object.id }}" />
+        <input name="username" type="hidden" value="{{ user.username }}" />
+        {{ permission_form.permission }}
+        <button class="btn btn-primary btn-xs">Change</button>
+      </form>
+    </div>
+    {% endif %}
   </td>
   <td class="col-xs-3" style="word-break: break-all" v-pre>
     {% if user.username != object.owner.username %}


### PR DESCRIPTION
Currently, the only way to change a member's role is to delete the member and add them again with the desired role. From a UX perspective, this is somewhat inconvenient. Therefore, we have added a small button next to each member's role label in the member list table to quickly support changing the member's role.
And since users cannot remove the owner's permission without transferring
ownership, we also have removed the button for this action from the UI.