### PR TITLE
Add ruff-check-format to Makefile "check" command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ bootstrap: $(APP_BIN)
 	$(APP_BIN) check
 
 .PHONY: check
-check: django-check promgen-test ruff-lint
+check: django-check promgen-test ruff-lint ruff-check-format
 
 .PHONY: django-check
 ## Django: Run Django checks
@@ -111,6 +111,10 @@ promgen-test: $(APP_BIN)
 .PHONY: ruff-lint
 ruff-lint: $(RUFF_BIN)
 	$(RUFF_BIN) check promgen
+
+.PHONY: ruff-check-format
+ruff-check-format: $(RUFF_BIN)
+	@$(RUFF_BIN) format --diff promgen
 
 .PHONY: migrate
 ## Django: Run migrations


### PR DESCRIPTION
Add a new command that uses the Ruff Formatter to check what changes would be made without actually formatting the code. This command will be useful for identifying formatting issues in Python code.