### PR TITLE
Add superusers to UserPermissionForm's choices

### DIFF
--- a/promgen/forms.py
+++ b/promgen/forms.py
@@ -284,7 +284,7 @@ class UserPermissionForm(forms.Form):
 
     def get_user_choices(self):
         for u in (
-            User.objects.filter(is_active=True, is_superuser=False)
+            User.objects.filter(is_active=True)
             .exclude(username=ANONYMOUS_USER_NAME)
             .order_by("username")
         ):


### PR DESCRIPTION
To synchronize with the owner selection list, we also display superusers. However, superusers still have full permissions over all Promgen objects regardless of the role assigned in the member list.