### PR TITLE
Fix the wrong format in the locale file

### DIFF
--- a/promgen/locale/ja/LC_MESSAGES/django.po
+++ b/promgen/locale/ja/LC_MESSAGES/django.po
@@ -224,5 +224,5 @@ msgstr "警告：オーナーを変更できるのは現在のオーナーだけ
 #: views.py:532
 #: views.py:830
 #: views.py:846
-msgid _("You do not have permission to change the owner.")
+msgid "You do not have permission to change the owner."
 msgstr "あなたはオーナーを変更する権限を持っていません。"


### PR DESCRIPTION
Fix the wrong format in ja/LC_MESSAGES/django.po