### PR TITLE
Update the confirmation message for farm deletion on Farm Detail page

### DIFF
--- a/promgen/templates/promgen/farm_detail.html
+++ b/promgen/templates/promgen/farm_detail.html
@@ -13,9 +13,14 @@
   {% if farm.editable %}
     <div>
       <a href="{% url 'farm-update' farm.id %}" class="btn btn-warning btn-sm">{% translate "Edit Farm" %}</a>
-      <form method="post" action="{% url 'farm-delete' farm.id %}" onsubmit="return confirm('Delete this farm?')" style="display: inline">
+      <form
+        method="post"
+        action="{% url 'farm-delete' farm.id %}"
+        onsubmit="return confirm('{% trans 'Are you sure you want to delete this farm? This action is permanent and cannot be undone.' %}')"
+        style="display: inline"
+      >
         {% csrf_token %}
-        <button class="btn btn-danger btn-sm">Delete Farm</button>
+        <button class="btn btn-danger btn-sm">{% trans "Delete Farm" %}</button>
       </form>
     </div>
   {% endif %}


### PR DESCRIPTION
At commit 8b90ea69, we added a confirmation message when users delete a local farm from the "Hosts" tab on the Project Detail page to emphasize the irreversibility of this action. We have updated this message for the same action on the Farm Detail page.