### PR TITLE
Remove excluded "farm" field from ProjectSerializer

### DIFF
--- a/promgen/serializers.py
+++ b/promgen/serializers.py
@@ -46,7 +46,7 @@ class ProjectSerializer(serializers.ModelSerializer):
     class Meta:
         model = models.Project
         lookup_field = "name"
-        exclude = ("id", "farm")
+        exclude = ("id",)
 
 
 class SenderSerializer(serializers.ModelSerializer):


### PR DESCRIPTION
After removing "farm" field from the Project model, calling the Project Retrieve API will cause an AssertionError. This happened because the serializer cannot find the "farm" field which was declared in the excluded field list. We have removed the "farm" field from the excluded field list of ProjectSerializer to resolve this bug.