### PR TITLE
Fix wrong classification of sending alert error

### DIFF
--- a/promgen/tests/test_util.py
+++ b/promgen/tests/test_util.py
@@ -1,0 +1,25 @@
+# Copyright (c) 2026 LY Corporation
+# These sources are released under the terms of the MIT license: see LICENSE
+
+from django.test import SimpleTestCase
+from requests import HTTPError
+from requests.models import Response
+
+from promgen import util
+
+
+class UtilTest(SimpleTestCase):
+    def test_categorize_error(self):
+        response = Response()
+        response.status_code = 404
+
+        cases = [
+            (ImportError("missing dependency"), "import_error"),
+            (HTTPError(response=response), "404_http_error"),
+            (HTTPError(), "other_error"),
+            (ValueError("bad input"), "other_error"),
+        ]
+
+        for error, expected in cases:
+            with self.subTest(error=type(error).__name__, expected=expected):
+                self.assertEqual(util.categorize_error(error), expected)

--- a/promgen/util.py
+++ b/promgen/util.py
@@ -169,7 +169,9 @@ def categorize_error(e: Exception) -> str:
     if isinstance(e, ImportError):
         return "import_error"
     elif isinstance(e, requests.HTTPError):
-        return str(e.response.status_code) + "_http_error" if e.response else "other_error"
+        return (
+            str(e.response.status_code) + "_http_error" if e.response is not None else "other_error"
+        )
     else:
         return "other_error"
 


### PR DESCRIPTION
At commit 359ca533, we added the categorize_error() function to classify the error_type of sending alert notification based on the HTTP code for the purpose of labeling metrics. However, there was a mistake causing error_type to always be "other_error". The reason is that the HTTP Requests library (requests) always returns False when executing the `bool (response)` statement in case of a response failure. (Ref: https://github.com/psf/requests/issues/2002)

We have fixed this issue and added the necessary tests for verification.