### PR TITLE
Fix alertmanager config path in docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,7 +72,7 @@ services:
       --config.file=/etc/alertmanager/alertmanager.yml
       --log.level=info
     volumes:
-      - ./docker:/etc/prometheus
+      - ./docker/alertmanager.yml:/etc/alertmanager/alertmanager.yml
 
   mysql:
     image: mysql:8


### PR DESCRIPTION
## Summary
Fix alertmanager config path in docker compose so it reads the configuration file from `docker/alertmanager.yml`. 

Currently the `alertmanager` service in `docker-compose.yml` mounts `./docker` to `/etc/prometheus`.

However, the `alertmanager` service runs with 
```bash
--config.file=/etc/alertmanager/alertmanager.yml
```
which reads the default config inside the image and hence ignoring the promgen webhook receiver.

## Verification
Before the fix:
```bash
docker compose up -d
docker compose exec alertmanager sh
cat /etc/alertmanager/alertmanager.yml
```
will return the default config
```yaml
route:
  group_by: ['alertname']
  group_wait: 30s
  group_interval: 5m
  repeat_interval: 1h
  receiver: 'web.hook'
receivers:
  - name: 'web.hook'
    webhook_configs:
      - url: 'http://127.0.0.1:5001/'
inhibit_rules:
  - source_matchers: [severity="critical"]
    target_matchers: [severity="warning"]
    # Apply inhibition if the alertname is the same.
    # CAUTION:
    #   If all label names listed in `equal` are missing
    #   from both the source and target alerts,
    #   the inhibition rule will apply!
    equal: [alertname, dev, instance]
```

instead of the config in `docker/alertmanager.yml`:
```yaml
receivers:
- name: "default"
  webhook_configs:
  - url: http://web:8000/api/v1/alerts
```

## Fix
Update the `docker-compose.yml` to correctly mount `./docker/alertmanager.yml` to `/etc/alertmanager/alertmanager.yml`.
