### PR TITLE
Remove the trailing slash in v2 APIs

### DIFF
--- a/promgen/schemas.py
+++ b/promgen/schemas.py
@@ -3,4 +3,4 @@ from drf_spectacular.openapi import AutoSchema
 
 class CustomSchema(AutoSchema):
     def is_excluded(self):
-        return not self.path.startswith("/rest/v2/") or self.path.startswith("/rest/v2/schema/")
+        return not self.path.startswith("/rest/v2/") or self.path == "/rest/v2/schema"

--- a/promgen/urls.py
+++ b/promgen/urls.py
@@ -30,7 +30,7 @@ router.register("shard", rest.ShardViewSet)
 router.register("project", rest.ProjectViewSet)
 router.register("farm", rest.FarmViewSet)
 
-v2_router = rest_v2.Router()
+v2_router = rest_v2.Router(trailing_slash=False)
 v2_router.register("logs", rest_v2.AuditViewSet)
 
 urlpatterns = [


### PR DESCRIPTION
By default, Django REST Framework initializes endpoints with a trailing slash. Additionally, if the router cannot resolve an endpoint without a trailing slash, Django's CommonMiddleware automatically responds with a redirect to the same endpoint with a trailing slash. As a result, Promgen's APIs currently support both with and without a trailing slash when accessed from a browser or a client capable of automatic redirection.

However, a RESTful API should not include a trailing slash because we are accessing resources, not directories. Moreover, automatic redirection is not appropriate in designing RESTful API. Therefore, we have decided to disable the trailing slash added by Django REST Framework. A 404 Not Found error will be returned when accessing an endpoint with a trailing slash.