### PR TITLE
Add new APIs for integrating with Notifier

### DIFF
--- a/promgen/filters.py
+++ b/promgen/filters.py
@@ -1,5 +1,10 @@
 import django_filters
+from django.contrib.auth.models import User
 from django.contrib.contenttypes.models import ContentType
+from django.db.models import F, Value
+from django.db.models.functions import Coalesce, NullIf
+
+from promgen import models
 
 
 class ShardFilter(django_filters.rest_framework.FilterSet):
@@ -31,6 +36,8 @@ def filter_content_type(queryset, name, value):
     try:
         if value == "group":
             content_type_id = ContentType.objects.get(model=value, app_label="auth").id
+        elif value == "user":
+            content_type_id = ContentType.objects.get_for_model(User).id
         else:
             content_type_id = ContentType.objects.get(model=value, app_label="promgen").id
 
@@ -84,3 +91,45 @@ class AuditFilter(django_filters.rest_framework.FilterSet):
         method=filter_content_type,
         help_text="Filter by parent content type model name. Example: parent_content_type=service",
     )
+
+
+class NotifierFilter(django_filters.rest_framework.FilterSet):
+    sender = django_filters.ChoiceFilter(
+        field_name="sender",
+        choices=[(module_name, module_name) for module_name, _ in models.Sender.driver_set()],
+        help_text="Filter by sender type. Example: sender=promgen.notification.email",
+    )
+    value = django_filters.CharFilter(
+        method="filter_value",
+        help_text="Filter by value (or alias if present) containing a specific substring. "
+        "Example: value=demo@example.com",
+    )
+    object_id = django_filters.NumberFilter(
+        field_name="object_id",
+        lookup_expr="exact",
+        help_text="Filter by exact object ID. Example: object_id=123",
+    )
+    content_type = django_filters.ChoiceFilter(
+        field_name="content_type",
+        choices=[
+            ("service", "Service"),
+            ("project", "Project"),
+            ("user", "User"),
+        ],
+        method=filter_content_type,
+        help_text="Filter by content type model name. Example: content_type=service",
+    )
+    owner = django_filters.CharFilter(
+        field_name="owner__username",
+        lookup_expr="exact",
+        help_text="Filter by exact owner username. Example: owner=Example Owner",
+    )
+
+    def filter_value(self, queryset, name, value):
+        # Annotate the queryset with an effective_value that uses alias if it's not empty,
+        # otherwise falls back to value. This is equivalent to the SQL expression:
+        # WHERE COALESCE(NULLIF(promgen_sender.alias,), promgen_sender.value) LIKE '%value%'
+        queryset = queryset.annotate(
+            effective_value=Coalesce(NullIf(F("alias"), Value("")), F("value"))
+        )
+        return queryset.filter(effective_value__contains=value)

--- a/promgen/fixtures/testcases.yaml
+++ b/promgen/fixtures/testcases.yaml
@@ -107,3 +107,25 @@
     body: "Updated test-project"
     user: 2
     created: 2024-03-19T01:00:00Z
+- model: promgen.sender
+  pk: 1
+  fields:
+    content_type: ["promgen", "service"]
+    object_id: 1
+    sender: promgen.notification.email
+    value: "email@example.com"
+    owner: 1
+- model: promgen.sender
+  pk: 2
+  fields:
+    content_type: ["promgen", "project"]
+    object_id: 1
+    sender: promgen.notification.slack
+    value: "https://hooks.slack.com/services/XXXXXXXXX/XXXXXXXXX/XXXXXXXXXXXXXXXXXXXXXXXX"
+    owner: 2
+- model: promgen.filter
+  pk: 1
+  fields:
+      sender: 1
+      name: "severity"
+      value: "critical"

--- a/promgen/rest_v2.py
+++ b/promgen/rest_v2.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2026 LINE Corporation
 # These sources are released under the terms of the MIT license: see LICENSE
+from http import HTTPStatus
 
+from django.contrib.auth.models import User
 from django.contrib.contenttypes.models import ContentType
 from django.db.models import Q
 from django.urls import re_path
@@ -8,6 +10,7 @@ from drf_spectacular.utils import extend_schema, extend_schema_view
 from drf_spectacular.views import SpectacularAPIView
 from rest_framework import mixins, pagination, routers, viewsets
 from rest_framework.authtoken.models import Token
+from rest_framework.decorators import action
 from rest_framework.renderers import TemplateHTMLRenderer
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -109,3 +112,74 @@ class AuditViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
             | Q(parent_content_type_id=project_ct.id, parent_object_id__in=projects)
             | Q(parent_content_type_id=group_ct.id, parent_object_id__in=groups)
         )
+
+
+@extend_schema_view(
+    list=extend_schema(summary="List Notifiers", description="Retrieve a list of all notifiers."),
+    update=extend_schema(summary="Update Notifier", description="Update an existing notifier."),
+    partial_update=extend_schema(
+        summary="Partially Update Notifier", description="Partially update an existing notifier."
+    ),
+    destroy=extend_schema(summary="Delete Notifier", description="Delete an existing notifier."),
+)
+@extend_schema(tags=["Notifier"])
+class NotifierViewSet(
+    mixins.ListModelMixin,
+    mixins.UpdateModelMixin,
+    mixins.DestroyModelMixin,
+    viewsets.GenericViewSet,
+):
+    queryset = models.Sender.objects.all().order_by("value")
+    filterset_class = filters.NotifierFilter
+    lookup_value_regex = "[^/]+"
+    lookup_field = "id"
+    pagination_class = PromgenPagination
+    permission_classes = [permissions.PromgenGuardianRestPermission]
+
+    def get_queryset(self):
+        if self.request.user.is_superuser or self.action != "list":
+            return self.queryset
+        accessible_projects = permissions.get_accessible_projects_for_user(self.request.user)
+        accessible_services = permissions.get_accessible_services_for_user(self.request.user)
+        project_ct = ContentType.objects.get_for_model(models.Project)
+        service_ct = ContentType.objects.get_for_model(models.Service)
+        user_ct = ContentType.objects.get_for_model(User)
+        return self.queryset.filter(
+            Q(content_type=project_ct, object_id__in=accessible_projects)
+            | Q(content_type=service_ct, object_id__in=accessible_services)
+            | Q(content_type=user_ct, object_id=self.request.user.id)
+        )
+
+    def get_serializer_class(self):
+        if self.action in ["update", "partial_update"]:
+            return serializers.UpdateNotifierSerializer
+        return serializers.NotifierSerializer
+
+    @extend_schema(
+        summary="Add Filter",
+        description="Add a filter to the specified notifier.",
+        request=serializers.FilterSerializer,
+        responses=serializers.NotifierSerializer,
+    )
+    @action(detail=True, methods=["post"], url_path="filters")
+    def add_filter(self, request, id):
+        notifier = self.get_object()
+        serializer = serializers.FilterSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        models.Filter.objects.create(
+            sender=notifier,
+            name=serializer.validated_data["name"],
+            value=serializer.validated_data["value"],
+        )
+        return Response(serializers.NotifierSerializer(notifier).data, status=HTTPStatus.CREATED)
+
+    @extend_schema(
+        summary="Delete Filter",
+        description="Delete a filter from the specified notifier.",
+    )
+    @action(detail=True, methods=["delete"], url_path="filters/(?P<filter_id>\d+)")
+    def delete_filter(self, request, id, filter_id):
+        notifier = self.get_object()
+        if notifier:
+            models.Filter.objects.filter(pk=filter_id).delete()
+        return Response(status=HTTPStatus.NO_CONTENT)

--- a/promgen/serializers.py
+++ b/promgen/serializers.py
@@ -185,3 +185,38 @@ class AuditSerializer(serializers.ModelSerializer):
             "parent_content_type",
             "parent_object_id",
         )
+
+
+class FilterSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = models.Filter
+        fields = ["id", "name", "value"]
+
+
+class NotifierSerializer(serializers.ModelSerializer):
+    owner = serializers.ReadOnlyField(source="owner.username")
+    content_name = serializers.SerializerMethodField()
+    content_type = serializers.ReadOnlyField(source="content_type.model")
+    filters = FilterSerializer(many=True, read_only=True, source="filter_set")
+    value = serializers.ReadOnlyField(source="show_value")
+
+    class Meta:
+        model = models.Sender
+        exclude = (
+            "object_id",
+            "alias",
+        )
+
+    def get_content_name(self, obj) -> str:
+        if hasattr(obj, "content_object"):
+            if hasattr(obj.content_object, "name"):
+                return obj.content_object.name
+            if hasattr(obj.content_object, "username"):
+                return obj.content_object.username
+        return None
+
+
+class UpdateNotifierSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = models.Sender
+        fields = ["enabled"]

--- a/promgen/tests/cases/test_rest_notifier.csv
+++ b/promgen/tests/cases/test_rest_notifier.csv
@@ -1,0 +1,32 @@
+case,user,permissions,method,viewname,kwargs,payload,expected_status,expected_response
+An unauthenticated user cannot list notifiers.,,,GET,api-v2:sender-list,,,401,
+An unauthenticated user cannot update a notifier.,,,PUT,api-v2:sender-detail,"{""id"": 1}","{""enabled"": false}",401,
+An unauthenticated user cannot partially update a notifier.,,,PATCH,api-v2:sender-detail,"{""id"": 1}","{""enabled"": false}",401,
+An unauthenticated user cannot delete a notifier.,,,DELETE,api-v2:sender-detail,"{""id"": 1}",,401,
+An unauthenticated user cannot add a notifier filter.,,,POST,api-v2:sender-add-filter,"{""id"": 1}","{""name"": ""name"", ""value"": ""value""}",401,
+An unauthenticated user cannot delete a notifier filter.,,,DELETE,api-v2:sender-delete-filter,"{""id"": 1, ""filter_id"": 1}",,401,
+An authenticated user without permissions sees no notifiers.,demo,,GET,api-v2:sender-list,,,200,"{""count"":0}"
+An authenticated user cannot update a notifier.,demo,,PUT,api-v2:sender-detail,"{""id"": 1}","{""enabled"": false}",403,
+An authenticated user cannot partially update a notifier.,demo,,PATCH,api-v2:sender-detail,"{""id"": 1}","{""enabled"": false}",403,
+An authenticated user cannot delete a notifier.,demo,,DELETE,api-v2:sender-detail,"{""id"": 1}",,403,
+An authenticated user cannot add a notifier filter.,demo,,POST,api-v2:sender-add-filter,"{""id"": 1}","{""name"": ""name"", ""value"": ""value""}",403,
+An authenticated user cannot delete a notifier filter.,demo,,DELETE,api-v2:sender-delete-filter,"{""id"": 1, ""filter_id"": 1}",,403,
+A viewer can list notifiers.,demo,"[{""codename"":""service_viewer"",""model"":""promgen.service"",""obj_pk"":1}]",GET,api-v2:sender-list,,,200,"{""example"":""rest.notifier.list.json""}"
+A viewer can get paginated notifier results.,demo,"[{""codename"":""service_viewer"",""model"":""promgen.service"",""obj_pk"":1}]",GET,api-v2:sender-list,,"{""page_number"": 1, ""page_size"": 1}",200,"{""results_length"":1}"
+A viewer can filter notifiers by content_type.,demo,"[{""codename"":""service_viewer"",""model"":""promgen.service"",""obj_pk"":1}]",GET,api-v2:sender-list,,"{""content_type"": ""service""}",200,"{""count"":1}"
+An invalid content_type returns HTTP 400.,demo,"[{""codename"":""service_viewer"",""model"":""promgen.service"",""obj_pk"":1}]",GET,api-v2:sender-list,,"{""content_type"": ""non-allowed""}",400,
+A viewer can filter notifiers by object_id.,demo,"[{""codename"":""service_viewer"",""model"":""promgen.service"",""obj_pk"":1}]",GET,api-v2:sender-list,,"{""object_id"": ""1""}",200,"{""count"":2}"
+A viewer can filter notifiers by owner username.,demo,"[{""codename"":""service_viewer"",""model"":""promgen.service"",""obj_pk"":1}]",GET,api-v2:sender-list,,"{""owner"": ""demo""}",200,"{""count"":1}"
+A viewer can filter notifiers by sender type.,demo,"[{""codename"":""service_viewer"",""model"":""promgen.service"",""obj_pk"":1}]",GET,api-v2:sender-list,,"{""sender"": ""promgen.notification.email""}",200,"{""count"":1}"
+An invalid sender type returns HTTP 400.,demo,"[{""codename"":""service_viewer"",""model"":""promgen.service"",""obj_pk"":1}]",GET,api-v2:sender-list,,"{""sender"": ""non-existent""}",400,
+A viewer can filter notifiers by value.,demo,"[{""codename"":""service_viewer"",""model"":""promgen.service"",""obj_pk"":1}]",GET,api-v2:sender-list,,"{""value"": ""services""}",200,"{""count"":1}"
+A viewer cannot update a notifier.,demo,"[{""codename"":""service_viewer"",""model"":""promgen.service"",""obj_pk"":1}]",PUT,api-v2:sender-detail,"{""id"": 1}","{""enabled"": false}",403,
+A viewer cannot partially update a notifier.,demo,"[{""codename"":""service_viewer"",""model"":""promgen.service"",""obj_pk"":1}]",PATCH,api-v2:sender-detail,"{""id"": 1}","{""enabled"": false}",403,
+A viewer cannot add filters to a notifier.,demo,"[{""codename"":""service_viewer"",""model"":""promgen.service"",""obj_pk"":1}]",POST,api-v2:sender-add-filter,"{""id"": 1}","{""name"": ""name"", ""value"": ""value""}",403,
+A viewer cannot delete filters from a notifier.,demo,"[{""codename"":""service_viewer"",""model"":""promgen.service"",""obj_pk"":1}]",DELETE,api-v2:sender-delete-filter,"{""id"": 1, ""filter_id"": 1}",,403,
+A viewer cannot delete a notifier.,demo,"[{""codename"":""service_viewer"",""model"":""promgen.service"",""obj_pk"":1}]",DELETE,api-v2:sender-detail,"{""id"": 1}",,403,
+An editor can update a notifier.,demo,"[{""codename"":""service_editor"",""model"":""promgen.service"",""obj_pk"":1}]",PUT,api-v2:sender-detail,"{""id"": 1}","{""enabled"": false}",200,
+An editor can partially update a notifier.,demo,"[{""codename"":""service_editor"",""model"":""promgen.service"",""obj_pk"":1}]",PATCH,api-v2:sender-detail,"{""id"": 1}","{""enabled"": false}",200,
+An editor can add filters to a notifier.,demo,"[{""codename"":""service_editor"",""model"":""promgen.service"",""obj_pk"":1}]",POST,api-v2:sender-add-filter,"{""id"": 2}","{""name"": ""name"", ""value"": ""value""}",201,
+An editor can delete filters from a notifier.,demo,"[{""codename"":""service_editor"",""model"":""promgen.service"",""obj_pk"":1}]",DELETE,api-v2:sender-delete-filter,"{""id"": 2, ""filter_id"": 2}",,204,
+An editor can delete a notifier.,demo,"[{""codename"":""service_editor"",""model"":""promgen.service"",""obj_pk"":1}]",DELETE,api-v2:sender-detail,"{""id"": 1}",,204,

--- a/promgen/tests/examples/rest.notifier.list.json
+++ b/promgen/tests/examples/rest.notifier.list.json
@@ -1,0 +1,33 @@
+{
+  "count": 2,
+  "next": null,
+  "previous": null,
+  "results": [
+    {
+      "content_name": "test-service",
+      "content_type": "service",
+      "enabled": true,
+      "filters": [
+        {
+          "id": 1,
+          "name": "severity",
+          "value": "critical"
+        }
+      ],
+      "id": 1,
+      "owner": "admin",
+      "sender": "promgen.notification.email",
+      "value": "email@example.com"
+    },
+    {
+      "content_name": "test-project",
+      "content_type": "project",
+      "enabled": true,
+      "filters": [],
+      "id": 2,
+      "owner": "demo",
+      "sender": "promgen.notification.slack",
+      "value": "https://hooks.slack.com/services/XXXXXXXXX/XXXXXXXXX/XXXXXXXXXXXXXXXXXXXXXXXX"
+    }
+  ]
+}

--- a/promgen/tests/notification/test_alertmanager.py
+++ b/promgen/tests/notification/test_alertmanager.py
@@ -36,7 +36,7 @@ class AlertmanagerTest(tests.PromgenTest):
         self.assertCount(models.AlertError, 0, "No failed alerts")
 
         self.assertCount(models.Alert, 1, "Alert should be queued")
-        self.assertEqual(mock_post.call_count, 2, "Two alerts should be sent")
+        self.assertEqual(mock_post.call_count, 3, "Three alerts should be sent")
 
         # Our sample is the same as the original's "alerts" field.
         _SAMPLE = tests.Data("notification", "alertmanager.json").json()

--- a/promgen/tests/notification/test_email.py
+++ b/promgen/tests/notification/test_email.py
@@ -20,6 +20,10 @@ class EmailTest(tests.PromgenTest):
         NotificationEmail.create(obj=one, value="foo@example.com", owner=self.user)
         NotificationEmail.create(obj=two, value="bar@example.com", owner=self.user)
 
+        # We disable all other senders to ensure that only our email sender is triggered
+        # during this test.
+        models.Sender.objects.exclude(sender=NotificationEmail.__module__).update(enabled=False)
+
         self.user = self.force_login(username="demo")
         permission = Permission.objects.get(codename="process_alert")
         self.user.user_permissions.add(permission)

--- a/promgen/tests/notification/test_linenotify.py
+++ b/promgen/tests/notification/test_linenotify.py
@@ -19,6 +19,12 @@ class LineNotifyTest(tests.PromgenTest):
         NotificationLineNotify.create(obj=one, value="hogehoge", owner=self.user)
         NotificationLineNotify.create(obj=two, value="asdfasdf", owner=self.user)
 
+        # We disable all other senders to ensure that only our LINENotify sender is triggered
+        # during this test.
+        models.Sender.objects.exclude(sender=NotificationLineNotify.__module__).update(
+            enabled=False
+        )
+
         self.user = self.force_login(username="demo")
         permission = Permission.objects.get(codename="process_alert")
         self.user.user_permissions.add(permission)

--- a/promgen/tests/notification/test_pagerduty.py
+++ b/promgen/tests/notification/test_pagerduty.py
@@ -22,6 +22,10 @@ class PagerDutyTest(tests.PromgenTest):
             obj=two, value="PagerDuty Proxy Server:integration_key_test", owner_id=1
         )
 
+        # We disable all other senders to ensure that only our PagerDuty sender is triggered
+        # during this test.
+        models.Sender.objects.exclude(sender=NotificationPagerDuty.__module__).update(enabled=False)
+
         self.user = self.force_login(username="demo")
         permission = Permission.objects.get(codename="process_alert")
         self.user.user_permissions.add(permission)

--- a/promgen/tests/notification/test_user_email.py
+++ b/promgen/tests/notification/test_user_email.py
@@ -37,12 +37,13 @@ class UserSplayTest(tests.PromgenTest):
         # Since we test the specifics elsewhere, just want to check
         # the count of calls here
         self.assertEqual(mock_post.call_count, 1, "Called LINE Notify")
-        self.assertEqual(mock_email.call_count, 1, "Called email")
+        self.assertEqual(mock_email.call_count, 2, "Called email")
 
     @override_settings(PROMGEN=tests.SETTINGS)
     @override_settings(CELERY_TASK_ALWAYS_EAGER=True)
     @mock.patch("promgen.notification.email.send_mail")
-    def test_failed_user(self, mock_email):
+    @mock.patch("promgen.util.post")
+    def test_failed_user(self, mock_email, mock_post):
         # We have one valid sender and one invalid one
         # The invalid one should be skipped while still letting
         # the valid one pass
@@ -60,7 +61,11 @@ class UserSplayTest(tests.PromgenTest):
     @override_settings(PROMGEN=tests.SETTINGS)
     @override_settings(CELERY_TASK_ALWAYS_EAGER=True)
     @mock.patch("promgen.notification.email.send_mail")
-    def test_enabled(self, mock_email):
+    @mock.patch("promgen.util.post")
+    def test_enabled(self, mock_email, mock_post):
+        # We disable all existing senders during this test.
+        models.Sender.objects.update(enabled=False)
+
         one = models.Service.objects.get(pk=1)
 
         # This notification is direct and disabled

--- a/promgen/tests/notification/test_webhook.py
+++ b/promgen/tests/notification/test_webhook.py
@@ -16,6 +16,10 @@ class WebhookTest(tests.PromgenTest):
         one = models.Project.objects.get(pk=1)
         two = models.Service.objects.get(pk=1)
 
+        # We disable all other senders to ensure that only our Webhook sender is triggered
+        # during this test.
+        models.Sender.objects.exclude(sender=NotificationWebhook.__module__).update(enabled=False)
+
         self.senderA = NotificationWebhook.create(
             obj=one, value="http://webhook.example.com/project", owner_id=1
         )
@@ -64,7 +68,7 @@ class WebhookTest(tests.PromgenTest):
         self.senderB.filter_set.create(name="severity", value="critical")
         self.senderB.filter_set.create(name="severity", value="major")
 
-        self.assertCount(models.Filter, 3, "Should be three filters")
+        self.assertCount(models.Filter, 4, "Should be four filters (One already exists)")
 
         response = self.fireAlert()
         self.assertRoute(response, rest.AlertReceiver, 202)

--- a/promgen/tests/test_rest.py
+++ b/promgen/tests/test_rest.py
@@ -12,6 +12,7 @@ from guardian.shortcuts import assign_perm, remove_perm
 from rest_framework.authtoken.models import Token
 
 from promgen import models, rest, signals, tests
+from promgen.notification.email import NotificationEmail
 
 
 class RestAPITest(tests.PromgenTest):
@@ -177,3 +178,47 @@ class RestAPITest(tests.PromgenTest):
         cases = tests.Data("cases", "test_rest_audit.csv").csv()
         for case in cases:
             self._run_rest_test(case)
+
+    @override_settings(PROMGEN=tests.SETTINGS)
+    def test_rest_notifier(self):
+        cases = tests.Data("cases", "test_rest_notifier.csv").csv()
+        for case in cases:
+            self._run_rest_test(case)
+
+    @override_settings(PROMGEN=tests.SETTINGS)
+    def test_rest_notifier_alias(self):
+        self.user = self.force_login(username="admin")
+        service = models.Service.objects.get(pk=1)
+        notifier = NotificationEmail.create(
+            obj=service, value="true_email@example.com", owner=self.user
+        )
+
+        response = self.client.get(reverse("api-v2:sender-list"), {"value": "true_email"})
+        self.assertEqual(response.data["count"], 1, "Expected one notifier matching the filter")
+        self.assertEqual(
+            response.data["results"][0]["value"],
+            "true_email@example.com",
+            "Expected the notifier's value to match the real email",
+        )
+
+        notifier.alias = "alias"
+        notifier.save()
+
+        response = self.client.get(reverse("api-v2:sender-list"), {"value": "true_email"})
+        self.assertEqual(
+            response.data["count"],
+            0,
+            "Expected no notifiers matching the filter after alias is set",
+        )
+
+        response = self.client.get(reverse("api-v2:sender-list"), {"value": "alias"})
+        self.assertEqual(
+            response.data["count"],
+            1,
+            "Expected one notifier matching the filter after alias is set",
+        )
+        self.assertEqual(
+            response.data["results"][0]["value"],
+            "alias",
+            "Expected the notifier's value to match the alias",
+        )

--- a/promgen/urls.py
+++ b/promgen/urls.py
@@ -32,6 +32,7 @@ router.register("farm", rest.FarmViewSet)
 
 v2_router = rest_v2.Router(trailing_slash=False)
 v2_router.register("logs", rest_v2.AuditViewSet)
+v2_router.register("notifiers", rest_v2.NotifierViewSet)
 
 urlpatterns = [
     path("admin/", admin.site.urls),


### PR DESCRIPTION
We have added several APIs to support users integrating with Promgen's Notifiers:
- List and filter Notifiers.
- Update/Partially update an existing Notifier.
- Add new filter to an existing Notifier.
- Delete filter of an existing Notifier.
- Delete an existing Notifier.