### PR TITLE
Add new APIs for integrating with Rule

### DIFF
--- a/promgen/filters.py
+++ b/promgen/filters.py
@@ -133,3 +133,35 @@ class NotifierFilter(django_filters.rest_framework.FilterSet):
             effective_value=Coalesce(NullIf(F("alias"), Value("")), F("value"))
         )
         return queryset.filter(effective_value__contains=value)
+
+
+class RuleFilterV2(django_filters.rest_framework.FilterSet):
+    name = django_filters.CharFilter(
+        field_name="name",
+        lookup_expr="contains",
+        help_text="Filter by rule name containing a specific substring. Example: name=Example Rule",
+    )
+    parent_rule_id = django_filters.NumberFilter(
+        field_name="parent__id",
+        lookup_expr="exact",
+        help_text="Filter by exact parent rule ID. Example: parent_rule_id=123",
+    )
+    enabled = django_filters.BooleanFilter(
+        field_name="enabled",
+        help_text="Filter by enabled status (true or false). Example: enabled=true",
+    )
+    object_id = django_filters.NumberFilter(
+        field_name="object_id",
+        lookup_expr="exact",
+        help_text="Filter by exact object ID. Example: object_id=123",
+    )
+    content_type = django_filters.ChoiceFilter(
+        field_name="content_type",
+        choices=[
+            ("service", "Service"),
+            ("project", "Project"),
+            ("site", "Site"),
+        ],
+        method=filter_content_type,
+        help_text="Filter by content type model name. Example: content_type=service",
+    )

--- a/promgen/fixtures/testcases.yaml
+++ b/promgen/fixtures/testcases.yaml
@@ -129,3 +129,38 @@
       sender: 1
       name: "severity"
       value: "critical"
+- model: promgen.rule
+  pk: 1
+  fields:
+    content_type: ["promgen", "service"]
+    object_id: 1
+    name: "Test Rule"
+    clause: "up == 0"
+    duration: 5m
+    enabled: true
+    description: "Test Rule Description"
+    labels: { "severity": "critical" }
+    annotations: { "rule": "http://promgen.example.com/rule/1" }
+- model: promgen.rule
+  pk: 2
+  fields:
+    content_type: ["promgen", "project"]
+    object_id: 1
+    name: "Test Rule 2"
+    clause: "up != 0"
+    duration: 1m
+    enabled: false
+    description: "Test Rule 2 Description"
+    labels: { "severity": "warning" }
+    annotations: { "rule": "http://promgen.example.com/rule/2" }
+    parent: 1
+- model: promgen.rule
+  pk: 3
+  fields:
+    content_type: ["promgen", "site"]
+    object_id: 1
+    name: "Site Rule"
+    clause: "up == 1"
+    duration: 1m
+    enabled: true
+    description: "Site Rule Description"

--- a/promgen/rest_v2.py
+++ b/promgen/rest_v2.py
@@ -183,3 +183,49 @@ class NotifierViewSet(
         if notifier:
             models.Filter.objects.filter(pk=filter_id).delete()
         return Response(status=HTTPStatus.NO_CONTENT)
+
+
+@extend_schema_view(
+    list=extend_schema(summary="List Rules", description="Retrieve a list of all rules."),
+    retrieve=extend_schema(
+        summary="Retrieve Rule", description="Retrieve detailed information about a specific rule."
+    ),
+    update=extend_schema(summary="Update Rule", description="Update an existing rule."),
+    partial_update=extend_schema(
+        summary="Partially Update Rule", description="Partially update an existing rule."
+    ),
+    destroy=extend_schema(summary="Delete Rule", description="Delete an existing rule."),
+)
+@extend_schema(tags=["Rule"])
+class RuleViewSet(
+    mixins.RetrieveModelMixin,
+    mixins.ListModelMixin,
+    mixins.UpdateModelMixin,
+    mixins.DestroyModelMixin,
+    viewsets.GenericViewSet,
+):
+    queryset = models.Rule.objects.all()
+    filterset_class = filters.RuleFilterV2
+    lookup_value_regex = "[^/]+"
+    lookup_field = "id"
+    pagination_class = PromgenPagination
+    permission_classes = [permissions.PromgenGuardianRestPermission]
+
+    def get_serializer_class(self):
+        if self.action in ["list"]:
+            return serializers.RuleRetrieveSimpleSerializer
+        return serializers.RuleRetrieveDetailSerializer
+
+    def get_queryset(self):
+        if self.request.user.is_superuser or self.action != "list":
+            return self.queryset
+        accessible_projects = permissions.get_accessible_projects_for_user(self.request.user)
+        accessible_services = permissions.get_accessible_services_for_user(self.request.user)
+        project_ct = ContentType.objects.get_for_model(models.Project)
+        service_ct = ContentType.objects.get_for_model(models.Service)
+        site_ct = ContentType.objects.get_for_model(models.Site, for_concrete_model=False)
+        return self.queryset.filter(
+            Q(content_type=project_ct, object_id__in=accessible_projects)
+            | Q(content_type=service_ct, object_id__in=accessible_services)
+            | Q(content_type=site_ct)
+        )

--- a/promgen/serializers.py
+++ b/promgen/serializers.py
@@ -220,3 +220,30 @@ class UpdateNotifierSerializer(serializers.ModelSerializer):
     class Meta:
         model = models.Sender
         fields = ["enabled"]
+
+
+class RuleRetrieveSimpleSerializer(serializers.ModelSerializer):
+    content_name = serializers.CharField(read_only=True, source="content_object.name")
+    content_type = serializers.CharField(read_only=True, source="content_type.model")
+
+    class Meta:
+        model = models.Rule
+        exclude = (
+            "description",
+            "annotations",
+            "labels",
+            "object_id",
+        )
+
+
+class RuleRetrieveDetailSerializer(serializers.ModelSerializer):
+    content_name = serializers.CharField(read_only=True, source="content_object.name")
+    content_type = serializers.CharField(read_only=True, source="content_type.model")
+
+    class Meta:
+        model = models.Rule
+        fields = "__all__"
+        read_only_fields = (
+            "parent",
+            "object_id",
+        )

--- a/promgen/tests/cases/test_rest_rule.csv
+++ b/promgen/tests/cases/test_rest_rule.csv
@@ -1,0 +1,35 @@
+case,user,permissions,method,viewname,kwargs,payload,expected_status,expected_response
+An unauthenticated user cannot list rules.,,,GET,api-v2:rule-list,,,401,
+An unauthenticated user cannot view rule detail.,,,GET,api-v2:rule-detail,"{""id"": 1}",,401,
+An unauthenticated user cannot update rule detail.,,,PUT,api-v2:rule-detail,"{""id"": 1}",{},401,
+An unauthenticated user cannot partially update rule detail.,,,PATCH,api-v2:rule-detail,"{""id"": 1}",{},401,
+An unauthenticated user cannot delete rule detail.,,,DELETE,api-v2:rule-detail,"{""id"": 1}",,401,
+An authenticated user without permissions can view only the Site Rule.,demo,,GET,api-v2:rule-list,,,200,"{""count"": 1}"
+An authenticated user without permissions can view Site Rule detail.,demo,,GET,api-v2:rule-detail,"{""id"": 3}",,200,
+An authenticated user without permissions cannot update Site Rule detail.,demo,,PUT,api-v2:rule-detail,"{""id"": 3}",,403,
+An authenticated user without permissions cannot partially update Site Rule detail.,demo,,PATCH,api-v2:rule-detail,"{""id"": 3}",,403,
+An authenticated user without permissions cannot delete Site Rule detail.,demo,,DELETE,api-v2:rule-detail,"{""id"": 3}",,403,
+An authenticated user without permissions cannot view project or service rule detail.,demo,,GET,api-v2:rule-detail,"{""id"": 1}",,403,
+A viewer can list rules.,demo,"[{""codename"": ""service_viewer"", ""model"": ""promgen.service"", ""obj_pk"": 1}]",GET,api-v2:rule-list,,,200,"{""example"": ""rest.rule.list.json""}"
+A viewer can get paginated rule results.,demo,"[{""codename"": ""service_viewer"", ""model"": ""promgen.service"", ""obj_pk"": 1}]",GET,api-v2:rule-list,,"{""page_number"": 1, ""page_size"": 1}",200,"{""results_length"": 1}"
+A viewer can filter rules by content_type.,demo,"[{""codename"": ""service_viewer"", ""model"": ""promgen.service"", ""obj_pk"": 1}]",GET,api-v2:rule-list,,"{""content_type"": ""service""}",200,"{""results_length"": 1}"
+An invalid content_type returns HTTP 400.,demo,"[{""codename"": ""service_viewer"", ""model"": ""promgen.service"", ""obj_pk"": 1}]",GET,api-v2:rule-list,,"{""content_type"": ""non-allowed""}",400,
+A viewer can filter rules by object_id.,demo,"[{""codename"": ""service_viewer"", ""model"": ""promgen.service"", ""obj_pk"": 1}]",GET,api-v2:rule-list,,"{""object_id"": 1}",200,"{""results_length"": 3}"
+A viewer can filter rules by enabled state.,demo,"[{""codename"": ""service_viewer"", ""model"": ""promgen.service"", ""obj_pk"": 1}]",GET,api-v2:rule-list,,"{""enabled"": ""true""}",200,"{""results_length"": 2}"
+A viewer can filter rules by parent rule ID.,demo,"[{""codename"": ""service_viewer"", ""model"": ""promgen.service"", ""obj_pk"": 1}]",GET,api-v2:rule-list,,"{""parent_rule_id"": 1}",200,"{""results_length"": 1}"
+A viewer can view rule detail.,demo,"[{""codename"": ""service_viewer"", ""model"": ""promgen.service"", ""obj_pk"": 1}]",GET,api-v2:rule-detail,"{""id"": 1}",,200,"{""example"": ""rest.rule.detail.json""}"
+A viewer cannot update a rule.,demo,"[{""codename"": ""service_viewer"", ""model"": ""promgen.service"", ""obj_pk"": 1}]",PUT,api-v2:rule-detail,"{""id"": 1}","{""annotations"": {""summary"": ""Test Rule Summary""}, ""clause"": ""up == 1"", ""description"": ""Test Rule Description"", ""duration"": ""5m"", ""enabled"": false, ""labels"": {""severity"": ""critical""}, ""name"": ""TestRuleUpdated""}",403,
+A viewer cannot partially update a rule.,demo,"[{""codename"": ""service_viewer"", ""model"": ""promgen.service"", ""obj_pk"": 1}]",PATCH,api-v2:rule-detail,"{""id"": 2}","{""enabled"": true}",403,
+A viewer cannot delete a rule.,demo,"[{""codename"": ""service_viewer"", ""model"": ""promgen.service"", ""obj_pk"": 1}]",DELETE,api-v2:rule-detail,"{""id"": 1}",,403,
+An editor can update a rule.,demo,"[{""codename"": ""service_editor"", ""model"": ""promgen.service"", ""obj_pk"": 1}]",PUT,api-v2:rule-detail,"{""id"": 1}","{""annotations"": {""summary"": ""Test Rule Summary""}, ""clause"": ""up == 1"", ""description"": ""Test Rule Description"", ""duration"": ""5m"", ""enabled"": false, ""labels"": {""severity"": ""critical""}, ""name"": ""TestRuleUpdated""}",200,
+An editor can partially update a rule.,demo,"[{""codename"": ""service_editor"", ""model"": ""promgen.service"", ""obj_pk"": 1}]",PATCH,api-v2:rule-detail,"{""id"": 2}","{""enabled"": true}",200,
+An editor can delete a rule.,demo,"[{""codename"": ""service_editor"", ""model"": ""promgen.service"", ""obj_pk"": 1}]",DELETE,api-v2:rule-detail,"{""id"": 1}",,204,
+An editor cannot update a Site Rule.,demo,"[{""codename"": ""service_editor"", ""model"": ""promgen.service"", ""obj_pk"": 1}]",PUT,api-v2:rule-detail,"{""id"": 3}","{""annotations"": {""summary"": ""Test Rule Summary""}, ""clause"": ""up == 1"", ""description"": ""Test Rule Description"", ""duration"": ""5m"", ""enabled"": false, ""labels"": {""severity"": ""critical""}, ""name"": ""TestRuleUpdated""}",403,
+An editor cannot partially update a Site Rule.,demo,"[{""codename"": ""service_editor"", ""model"": ""promgen.service"", ""obj_pk"": 1}]",PATCH,api-v2:rule-detail,"{""id"": 3}","{""enabled"": true}",403,
+An editor cannot delete a Site Rule.,demo,"[{""codename"": ""service_editor"", ""model"": ""promgen.service"", ""obj_pk"": 1}]",DELETE,api-v2:rule-detail,"{""id"": 3}",,403,
+A service admin cannot update a Site Rule.,demo,"[{""codename"": ""service_admin"", ""model"": ""promgen.service"", ""obj_pk"": 1}]",PUT,api-v2:rule-detail,"{""id"": 3}","{""annotations"": {""summary"": ""Test Rule Summary""}, ""clause"": ""up == 1"", ""description"": ""Test Rule Description"", ""duration"": ""5m"", ""enabled"": false, ""labels"": {""severity"": ""critical""}, ""name"": ""TestRuleUpdated""}",403,
+A service admin cannot partially update a Site Rule.,demo,"[{""codename"": ""service_admin"", ""model"": ""promgen.service"", ""obj_pk"": 1}]",PATCH,api-v2:rule-detail,"{""id"": 3}","{""enabled"": true}",403,
+A service admin cannot delete a Site Rule.,demo,"[{""codename"": ""service_admin"", ""model"": ""promgen.service"", ""obj_pk"": 1}]",DELETE,api-v2:rule-detail,"{""id"": 3}",,403,
+A Site Admin can update a Site Rule.,admin,"",PUT,api-v2:rule-detail,"{""id"": 3}","{""annotations"": {""summary"": ""Test Rule Summary""}, ""clause"": ""up == 1"", ""description"": ""Test Rule Description"", ""duration"": ""5m"", ""enabled"": false, ""labels"": {""severity"": ""critical""}, ""name"": ""TestRuleUpdated""}",200,
+A Site Admin can partially update a Site Rule.,admin,"",PATCH,api-v2:rule-detail,"{""id"": 3}","{""enabled"": true}",200,
+A Site Admin can delete a Site Rule.,admin,"",DELETE,api-v2:rule-detail,"{""id"": 3}",,204,

--- a/promgen/tests/examples/export.rule.yml
+++ b/promgen/tests/examples/export.rule.yml
@@ -9,3 +9,9 @@ groups:
         for: 1s
         labels:
           severity: high
+      - alert: Site Rule
+        annotations:
+          rule: http://promgen.example.com/rule/3
+        expr: up == 1
+        for: 1m
+        labels: {}

--- a/promgen/tests/examples/rest.rule.detail.json
+++ b/promgen/tests/examples/rest.rule.detail.json
@@ -1,0 +1,18 @@
+{
+  "annotations": {
+    "rule": "http://promgen.example.com/rule/1"
+  },
+  "clause": "up == 0",
+  "content_name": "test-service",
+  "content_type": "service",
+  "object_id": 1,
+  "description": "Test Rule Description",
+  "duration": "5m",
+  "enabled": true,
+  "id": 1,
+  "labels": {
+    "severity": "critical"
+  },
+  "name": "Test Rule",
+  "parent": null
+}

--- a/promgen/tests/examples/rest.rule.list.json
+++ b/promgen/tests/examples/rest.rule.list.json
@@ -1,0 +1,37 @@
+{
+  "count": 3,
+  "next": null,
+  "previous": null,
+  "results": [
+    {
+      "clause": "up == 1",
+      "content_name": "CI Test",
+      "content_type": "site",
+      "duration": "1m",
+      "enabled": true,
+      "id": 3,
+      "name": "Site Rule",
+      "parent": null
+    },
+    {
+      "clause": "up != 0",
+      "content_name": "test-project",
+      "content_type": "project",
+      "duration": "1m",
+      "enabled": false,
+      "id": 2,
+      "name": "Test Rule 2",
+      "parent": 1
+    },
+    {
+      "clause": "up == 0",
+      "content_name": "test-service",
+      "content_type": "service",
+      "duration": "5m",
+      "enabled": true,
+      "id": 1,
+      "name": "Test Rule",
+      "parent": null
+    }
+  ]
+}

--- a/promgen/tests/test_alert_rules.py
+++ b/promgen/tests/test_alert_rules.py
@@ -22,6 +22,12 @@ groups:
     for: 1s
     labels:
       severity: high
+  - alert: Site Rule
+    annotations:
+      rule: https://promgen.example.com/rule/3
+    expr: up == 1
+    for: 1m
+    labels: {}
 """.lstrip().encode("utf-8")
 
 TEST_SETTINGS = tests.Data("examples", "promgen.yml").yaml()
@@ -57,7 +63,7 @@ class RuleTest(tests.PromgenTest):
 
         # Includes count of our setUp rule + imported rules
         self.assertRoute(response, views.RuleImport, status=200)
-        self.assertCount(models.Rule, 3, "Missing Rule")
+        self.assertCount(models.Rule, 5, "Missing Rule")
 
     @skip
     @override_settings(PROMGEN=TEST_SETTINGS)
@@ -98,8 +104,8 @@ class RuleTest(tests.PromgenTest):
             {"rules": tests.Data("examples", "import.rule.yml").raw()},
         )
 
-        # Should only be a single rule from our initial setup
-        self.assertCount(models.Rule, 1, "Missing Rule")
+        # Should only be number of rules from our initial setup
+        self.assertCount(models.Rule, 3, "Missing Rule")
 
     @mock.patch("django.dispatch.dispatcher.Signal.send")
     def test_macro(self, mock_post):

--- a/promgen/tests/test_rest.py
+++ b/promgen/tests/test_rest.py
@@ -222,3 +222,9 @@ class RestAPITest(tests.PromgenTest):
             "alias",
             "Expected the notifier's value to match the alias",
         )
+
+    @override_settings(PROMGEN=tests.SETTINGS)
+    def test_rest_rule(self):
+        cases = tests.Data("cases", "test_rest_rule.csv").csv()
+        for case in cases:
+            self._run_rest_test(case)

--- a/promgen/urls.py
+++ b/promgen/urls.py
@@ -33,6 +33,7 @@ router.register("farm", rest.FarmViewSet)
 v2_router = rest_v2.Router(trailing_slash=False)
 v2_router.register("logs", rest_v2.AuditViewSet)
 v2_router.register("notifiers", rest_v2.NotifierViewSet)
+v2_router.register("rules", rest_v2.RuleViewSet)
 
 urlpatterns = [
     path("admin/", admin.site.urls),


### PR DESCRIPTION
We have added several APIs to support users integrating with Promgen's Rules:
- List and filter Rules.
- Retrieve detail information of an existing Rule.
- Update/Partially update an existing Rule.
- Delete an existing Rule.