### PR TITLE
Add new APIs for integrating with Farm

### DIFF
--- a/promgen/filters.py
+++ b/promgen/filters.py
@@ -28,8 +28,17 @@ class RuleFilter(django_filters.rest_framework.FilterSet):
 
 
 class FarmFilter(django_filters.rest_framework.FilterSet):
-    name = django_filters.CharFilter(field_name="name", lookup_expr="contains")
-    source = django_filters.CharFilter(field_name="source", lookup_expr="exact")
+    name = django_filters.CharFilter(
+        field_name="name",
+        lookup_expr="contains",
+        help_text="Filter by farm name containing a specific substring. Example: name=Example Farm",
+    )
+    source = django_filters.ChoiceFilter(
+        field_name="source",
+        choices=[(name, name) for name, _ in models.Farm.driver_set()],
+        lookup_expr="exact",
+        help_text="Filter by exact source name. Example: source=promgen",
+    )
 
 
 def filter_content_type(queryset, name, value):

--- a/promgen/fixtures/testcases.yaml
+++ b/promgen/fixtures/testcases.yaml
@@ -54,6 +54,12 @@
     name: test-farm
     source: promgen
     project: 1
+- model: promgen.farm
+  pk: 2
+  fields:
+    name: other-farm
+    source: external
+    project: 2
 - model: promgen.project
   pk: 1
   fields:
@@ -68,6 +74,11 @@
     owner: 1
     service: 1
     shard: 1
+- model: promgen.host
+  pk: 1
+  fields:
+    name: example.com
+    farm: 1
 - model: promgen.exporter
   pk: 1
   fields:

--- a/promgen/rest_v2.py
+++ b/promgen/rest_v2.py
@@ -4,18 +4,24 @@ from http import HTTPStatus
 
 from django.contrib.auth.models import User
 from django.contrib.contenttypes.models import ContentType
+from django.core.exceptions import ValidationError as DjangoValidationError
 from django.db.models import Q
 from django.urls import re_path
-from drf_spectacular.utils import extend_schema, extend_schema_view
+from drf_spectacular.utils import (
+    OpenApiParameter,
+    extend_schema,
+    extend_schema_view,
+)
 from drf_spectacular.views import SpectacularAPIView
 from rest_framework import mixins, pagination, routers, viewsets
 from rest_framework.authtoken.models import Token
 from rest_framework.decorators import action
+from rest_framework.exceptions import MethodNotAllowed, ValidationError
 from rest_framework.renderers import TemplateHTMLRenderer
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from promgen import filters, models, permissions, serializers
+from promgen import discovery, filters, models, permissions, serializers, signals, validators
 
 
 class SpectacularRapiDocView(APIView):
@@ -229,3 +235,240 @@ class RuleViewSet(
             | Q(content_type=service_ct, object_id__in=accessible_services)
             | Q(content_type=site_ct)
         )
+
+
+@extend_schema_view(
+    list=extend_schema(
+        summary="List Created Farms", description="Retrieve a list of all created farms."
+    ),
+    retrieve=extend_schema(
+        summary="Retrieve Farm", description="Retrieve detailed information about a specific farm."
+    ),
+    update=extend_schema(summary="Update Farm", description="Update an existing farm."),
+    partial_update=extend_schema(
+        summary="Partially Update Farm", description="Partially update an existing farm."
+    ),
+    destroy=extend_schema(summary="Delete Farm", description="Delete an existing farm."),
+)
+@extend_schema(tags=["Farm"])
+class FarmViewSet(
+    mixins.RetrieveModelMixin,
+    mixins.UpdateModelMixin,
+    mixins.DestroyModelMixin,
+    mixins.ListModelMixin,
+    viewsets.GenericViewSet,
+):
+    queryset = models.Farm.objects.all()
+    filterset_class = filters.FarmFilter
+    serializer_class = serializers.FarmRetrieveSerializer
+    lookup_value_regex = "[^/]+"
+    lookup_field = "id"
+    pagination_class = PromgenPagination
+    permission_classes = [permissions.PromgenGuardianRestPermission]
+
+    def get_queryset(self):
+        if self.request.user.is_superuser or self.action != "list":
+            return self.queryset
+        accessible_projects = permissions.get_accessible_projects_for_user(self.request.user)
+        return self.queryset.filter(project__in=accessible_projects)
+
+    def update(self, request, *args, **kwargs):
+        farm = self.get_object()
+        if farm.source != discovery.FARM_DEFAULT:
+            raise ValidationError({"detail": "Only local farms can be updated."})
+        return super().update(request, *args, **kwargs)
+
+    def partial_update(self, request, *args, **kwargs):
+        farm = self.get_object()
+        if farm.source != discovery.FARM_DEFAULT:
+            raise ValidationError({"detail": "Only local farms can be updated."})
+        return super().partial_update(request, *args, **kwargs)
+
+    @extend_schema(
+        summary="List Farm Sources",
+        description="Retrieve available farm sources and whether they are remote.",
+        parameters=[
+            OpenApiParameter(
+                name="name",
+                required=False,
+                type=str,
+                description="Filter by source name containing a specific substring. "
+                "Example: name=Example Source",
+            ),
+            OpenApiParameter(
+                name="remote",
+                required=False,
+                type=bool,
+                description="Filter by whether the source is remote. Example: remote=true",
+            ),
+        ],
+        responses=serializers.FarmSourceSerializer(many=True),
+    )
+    @action(detail=False, methods=["get"], filterset_class=None)
+    def sources(self, request):
+        source_data = sorted(
+            [{"name": name, "remote": driver.remote} for name, driver in models.Farm.driver_set()],
+            key=lambda source: source["name"].lower(),
+        )
+
+        name = request.query_params.get("name")
+        if name:
+            source_data = [
+                source for source in source_data if name.lower() in source["name"].lower()
+            ]
+
+        remote = request.query_params.get("remote")
+        if remote is not None:
+            if remote.lower() == "true":
+                remote_bool = True
+            elif remote.lower() == "false":
+                remote_bool = False
+            else:
+                raise ValidationError({"detail": "Invalid value for remote. Use true or false."})
+            source_data = [source for source in source_data if source["remote"] == remote_bool]
+
+        page = self.paginate_queryset(source_data)
+        return self.get_paginated_response(serializers.FarmSourceSerializer(page, many=True).data)
+
+    @extend_schema(
+        summary="List Remote Farms by Source",
+        description="Retrieve remote farm names from the specified remote source.",
+        parameters=[
+            OpenApiParameter(
+                name="name",
+                required=False,
+                type=str,
+                description="Filter by farm name containing a specific substring. "
+                "Example: name=Example Farm",
+            )
+        ],
+        responses=serializers.RemoteFarmSerializer(many=True),
+    )
+    @action(
+        detail=False,
+        methods=["get"],
+        url_path=r"remotes/(?P<source>[^/]+)",
+        filterset_class=None,
+    )
+    def remote(self, request, source):
+        driver = None
+        for driver_name, farm_driver in models.Farm.driver_set():
+            if driver_name == source:
+                driver = farm_driver
+                break
+
+        if driver is None:
+            raise ValidationError({"detail": "Unknown farm source."})
+        if not driver.remote:
+            raise ValidationError({"detail": "Only remote farm sources are supported."})
+
+        name = request.query_params.get("name")
+        remote_farms = set(models.Farm.fetch(source))
+        if name:
+            remote_farms = [farm_name for farm_name in remote_farms if name in farm_name]
+
+        farm_data = sorted(
+            ({"name": farm_name} for farm_name in remote_farms),
+            key=lambda item: item["name"].lower(),
+        )
+        page = self.paginate_queryset(farm_data)
+        return self.get_paginated_response(serializers.RemoteFarmSerializer(page, many=True).data)
+
+    @extend_schema(
+        summary="List Hosts in Farm",
+        description="Retrieve all hosts associated with the specified farm.",
+        parameters=[
+            OpenApiParameter(name="page_number", required=False, type=int),
+            OpenApiParameter(name="page_size", required=False, type=int),
+        ],
+        responses=serializers.HostRetrieveSerializer(many=True),
+    )
+    @action(detail=True, methods=["get"], filterset_class=None)
+    def hosts(self, request, id):
+        farm = self.get_object()
+        hosts = farm.host_set.all()
+        page = self.paginate_queryset(hosts)
+        return self.get_paginated_response(serializers.HostRetrieveSerializer(page, many=True).data)
+
+    @extend_schema(
+        summary="Register Hosts",
+        description="Register new hosts for the specified farm. "
+        "Hosts are only registered if all of the provided hostnames are valid.",
+        request=serializers.HostListSerializer,
+        responses={204: None},
+    )
+    @hosts.mapping.post
+    def register_host(self, request, id):
+        farm = self.get_object()
+        hostnames = request.data.get("hosts", [])
+        valid_hosts = set()
+        invalid_hosts = set()
+        for hostname in hostnames:
+            if hostname == "":
+                continue
+            try:
+                validators.hostname(hostname)
+            except DjangoValidationError:
+                invalid_hosts.add(hostname)
+            valid_hosts.add(hostname)
+
+        if invalid_hosts:
+            raise ValidationError(
+                {"detail": "Invalid hostnames.", "extras": {"invalid_hosts": list(invalid_hosts)}}
+            )
+
+        for valid_host in valid_hosts:
+            models.Host.objects.get_or_create(name=valid_host, farm_id=farm.id)
+        return Response(status=HTTPStatus.NO_CONTENT)
+
+    @extend_schema(exclude=True)
+    @action(detail=True, methods=["get"], url_path="hosts/(?P<host_id>\d+)", pagination_class=None)
+    def host(self, request, id, host_id):
+        raise MethodNotAllowed(request.method)
+
+    @extend_schema(
+        summary="Delete Hosts",
+        description="Delete hosts from the specified farm.",
+    )
+    @host.mapping.delete
+    def delete_host(self, request, id, host_id):
+        farm = self.get_object()
+        models.Host.objects.filter(pk=host_id, farm=farm).delete()
+        return Response(status=HTTPStatus.NO_CONTENT)
+
+    @extend_schema(
+        summary="Sync Farm",
+        description="Refresh hosts from the farm source.",
+        request=None,
+        responses=serializers.FarmRetrieveSerializer,
+    )
+    @action(detail=True, methods=["post"], pagination_class=None, filterset_class=None)
+    def sync(self, request, id):
+        farm = self.get_object()
+        if farm.source == discovery.FARM_DEFAULT:
+            raise ValidationError({"detail": "Only remote farms can be synced."})
+        # If any hosts are added or removed, then we want to trigger a config refresh
+        if any(farm.refresh()):
+            signals.trigger_write_config.send(request)
+        return Response(serializers.FarmRetrieveSerializer(farm).data)
+
+    @extend_schema(
+        summary="Convert to Local Farm",
+        description="Convert a remote farm to a local Promgen farm source.",
+        request=None,
+        responses=serializers.FarmRetrieveSerializer,
+    )
+    @action(
+        detail=True,
+        methods=["post"],
+        url_path="convert-to-local",
+        pagination_class=None,
+        filterset_class=None,
+    )
+    def convert_to_local_farm(self, request, id):
+        farm = self.get_object()
+        if farm.source == discovery.FARM_DEFAULT:
+            raise ValidationError({"detail": "Only remote farms can be converted to local."})
+        farm.source = discovery.FARM_DEFAULT
+        farm.save()
+        return Response(serializers.FarmRetrieveSerializer(farm).data)

--- a/promgen/serializers.py
+++ b/promgen/serializers.py
@@ -247,3 +247,38 @@ class RuleRetrieveDetailSerializer(serializers.ModelSerializer):
             "parent",
             "object_id",
         )
+
+
+class HostRetrieveSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = models.Host
+        fields = "__all__"
+
+
+class FarmRetrieveSerializer(serializers.ModelSerializer):
+    project = serializers.ReadOnlyField(source="project.name")
+    project_id = serializers.ReadOnlyField(source="project.id")
+    remote = serializers.SerializerMethodField()
+
+    class Meta:
+        model = models.Farm
+        fields = "__all__"
+        read_only_fields = ("id", "project", "source")
+
+    def get_remote(self, obj) -> bool:
+        return obj.driver.remote
+
+
+class HostListSerializer(serializers.Serializer):
+    hosts = serializers.ListField(
+        child=serializers.CharField(), help_text="List of hostnames to add."
+    )
+
+
+class FarmSourceSerializer(serializers.Serializer):
+    name = serializers.CharField()
+    remote = serializers.BooleanField()
+
+
+class RemoteFarmSerializer(serializers.Serializer):
+    name = serializers.CharField()

--- a/promgen/tests/cases/test_rest_farm.csv
+++ b/promgen/tests/cases/test_rest_farm.csv
@@ -1,0 +1,52 @@
+case,user,permissions,method,viewname,kwargs,payload,expected_status,expected_response
+An unauthenticated user cannot list farms.,,,GET,api-v2:farm-list,,,401,
+An unauthenticated user cannot view farm detail.,,,GET,api-v2:farm-detail,"{""id"": 1}",,401,
+An unauthenticated user cannot update a farm.,,,PUT,api-v2:farm-detail,"{""id"": 1}","{""name"": ""test-farm-updated""}",401,
+An unauthenticated user cannot partially update a farm.,,,PATCH,api-v2:farm-detail,"{""id"": 1}","{""name"": ""test-farm-updated""}",401,
+An unauthenticated user cannot delete a farm.,,,DELETE,api-v2:farm-detail,"{""id"": 1}",,401,
+An unauthenticated user cannot list farm sources.,,,GET,api-v2:farm-sources,,,401,
+An unauthenticated user cannot list remote farms.,,,GET,api-v2:farm-remote,"{""source"": ""external""}",,401,
+An unauthenticated user cannot view farm hosts.,,,GET,api-v2:farm-hosts,"{""id"": 1}",,401,
+An unauthenticated user cannot add farm hosts.,,,POST,api-v2:farm-hosts,"{""id"": 1}","{""hosts"": [""new.example.com""]}",401,
+An unauthenticated user cannot delete a farm host.,,,DELETE,api-v2:farm-host,"{""id"": 1, ""host_id"": 1}",,401,
+An unauthenticated user cannot sync a farm.,,,POST,api-v2:farm-sync,"{""id"": 1}",,401,
+An unauthenticated user cannot convert a farm to a local farm.,,,POST,api-v2:farm-convert-to-local-farm,"{""id"": 1}",,401,
+An authenticated user without permissions sees no farms.,demo,,GET,api-v2:farm-list,,,200,"{""count"": 0}"
+An authenticated user without permissions cannot view farm detail.,demo,,GET,api-v2:farm-detail,"{""id"": 1}",,403,
+An authenticated user without permissions cannot update a farm.,demo,,PUT,api-v2:farm-detail,"{""id"": 1}","{""name"": ""test-farm-updated""}",403,
+An authenticated user without permissions cannot partially update a farm.,demo,,PATCH,api-v2:farm-detail,"{""id"": 1}","{""name"": ""test-farm-updated""}",403,
+An authenticated user without permissions cannot delete a farm.,demo,,DELETE,api-v2:farm-detail,"{""id"": 1}",,403,
+An authenticated user without permissions cannot view farm hosts.,demo,,GET,api-v2:farm-hosts,"{""id"": 1}",,403,
+An authenticated user without permissions cannot add farm hosts.,demo,,POST,api-v2:farm-hosts,"{""id"": 1}","{""hosts"": [""new.example.com""]}",403,
+An authenticated user without permissions cannot delete a farm host.,demo,,DELETE,api-v2:farm-host,"{""id"": 1, ""host_id"": 1}",,403,
+An authenticated user without permissions cannot sync a farm.,demo,,POST,api-v2:farm-sync,"{""id"": 1}",,403,
+An authenticated user without permissions cannot convert a farm to a local farm.,demo,,POST,api-v2:farm-convert-to-local-farm,"{""id"": 1}",,403,
+An authenticated user without permissions can list farm sources.,demo,,GET,api-v2:farm-sources,,,200,"{ ""response_body"": { ""count"": 2, ""next"": null, ""previous"": null, ""results"": [ { ""name"": ""external"", ""remote"": true }, { ""name"": ""promgen"", ""remote"": false } ] } }"
+An authenticated user without permissions can list farm sources with pagination.,demo,,GET,api-v2:farm-sources,,"{""page_number"": 1, ""page_size"": 1}",200,"{""results_length"": 1}"
+An authenticated user without permissions can filter farm sources by name.,demo,,GET,api-v2:farm-sources,,"{""name"": ""ext""}",200,"{""results_length"": 1}"
+An authenticated user without permissions can filter farm sources by remote.,demo,,GET,api-v2:farm-sources,,"{""remote"": ""true""}",200,"{""results_length"": 1}"
+An authenticated user without permissions can list remote farms.,demo,,GET,api-v2:farm-remote,"{""source"": ""external""}",,200,"{ ""response_body"": { ""count"": 2, ""next"": null, ""previous"": null, ""results"": [ {""name"": ""other-farm""}, {""name"": ""other-farm-2""} ] } }"
+An authenticated user without permissions can list remote farms with pagination.,demo,,GET,api-v2:farm-remote,"{""source"": ""external""}","{""page_number"": 1, ""page_size"": 1}",200,"{""results_length"": 1}"
+An authenticated user without permissions can filter remote farms by name.,demo,,GET,api-v2:farm-remote,"{""source"": ""external""}","{""name"": ""farm-2""}",200,"{""results_length"": 1}"
+Remote farm listing rejects unknown source.,demo,,GET,api-v2:farm-remote,"{""source"": ""unknown""}",,400,
+Remote farm listing requires a remote source.,demo,,GET,api-v2:farm-remote,"{""source"": ""promgen""}",,400,
+A viewer can list farms.,demo,"[{""codename"": ""project_viewer"", ""model"": ""promgen.project"", ""obj_pk"": 1}, {""codename"": ""project_viewer"", ""model"": ""promgen.project"", ""obj_pk"": 2}]",GET,api-v2:farm-list,,,200,"{""example"": ""rest.farm.list.json""}"
+A viewer can list farms with pagination.,demo,"[{""codename"": ""project_viewer"", ""model"": ""promgen.project"", ""obj_pk"": 1}, {""codename"": ""project_viewer"", ""model"": ""promgen.project"", ""obj_pk"": 2}]",GET,api-v2:farm-list,,"{""page_number"": 1, ""page_size"": 1}",200,"{""results_length"": 1}"
+A viewer can filter farms by name.,demo,"[{""codename"": ""project_viewer"", ""model"": ""promgen.project"", ""obj_pk"": 1}, {""codename"": ""project_viewer"", ""model"": ""promgen.project"", ""obj_pk"": 2}]",GET,api-v2:farm-list,,"{""name"": ""test-farm""}",200,"{""count"": 1}"
+A viewer can filter farms by source.,demo,"[{""codename"": ""project_viewer"", ""model"": ""promgen.project"", ""obj_pk"": 1}, {""codename"": ""project_viewer"", ""model"": ""promgen.project"", ""obj_pk"": 2}]",GET,api-v2:farm-list,,"{""source"": ""promgen""}",200,"{""count"": 1}"
+A viewer can view farm detail.,demo,"[{""codename"": ""project_viewer"", ""model"": ""promgen.project"", ""obj_pk"": 1}]",GET,api-v2:farm-detail,"{""id"": 1}",,200,"{""example"": ""rest.farm.detail.json""}"
+A viewer cannot update a farm.,demo,"[{""codename"": ""project_viewer"", ""model"": ""promgen.project"", ""obj_pk"": 1}]",PUT,api-v2:farm-detail,"{""id"": 1}","{""name"": ""test-farm-updated""}",403,
+A viewer cannot partially update a farm.,demo,"[{""codename"": ""project_viewer"", ""model"": ""promgen.project"", ""obj_pk"": 1}]",PATCH,api-v2:farm-detail,"{""id"": 1}","{""name"": ""test-farm-updated""}",403,
+A viewer cannot delete a farm.,demo,"[{""codename"": ""project_viewer"", ""model"": ""promgen.project"", ""obj_pk"": 1}]",DELETE,api-v2:farm-detail,"{""id"": 1}",,403,
+A viewer can view farm hosts.,demo,"[{""codename"": ""project_viewer"", ""model"": ""promgen.project"", ""obj_pk"": 1}]",GET,api-v2:farm-hosts,"{""id"": 1}",,200,"{""example"": ""rest.farm.hosts.json""}"
+A viewer cannot add hosts to a farm.,demo,"[{""codename"": ""project_viewer"", ""model"": ""promgen.project"", ""obj_pk"": 1}]",POST,api-v2:farm-hosts,"{""id"": 1}","{""hosts"": [""new.example.com""]}",403,
+A viewer cannot delete a farm host.,demo,"[{""codename"": ""project_viewer"", ""model"": ""promgen.project"", ""obj_pk"": 1}]",DELETE,api-v2:farm-host,"{""id"": 1, ""host_id"": 1}",,403,
+An editor can update a farm.,demo,"[{""codename"": ""project_editor"", ""model"": ""promgen.project"", ""obj_pk"": 1}]",PUT,api-v2:farm-detail,"{""id"": 1}","{""name"": ""test-farm-updated""}",200,"{""field_equals"": [{""model"": ""promgen.farm"", ""filters"": {""id"": 1}, ""field"": ""name"", ""value"": ""test-farm-updated""}]}"
+An editor can partially update a farm.,demo,"[{""codename"": ""project_editor"", ""model"": ""promgen.project"", ""obj_pk"": 1}]",PATCH,api-v2:farm-detail,"{""id"": 1}","{""name"": ""test-farm-patched""}",200,"{""field_equals"": [{""model"": ""promgen.farm"", ""filters"": {""id"": 1}, ""field"": ""name"", ""value"": ""test-farm-patched""}]}"
+An editor can add hosts to a farm.,demo,"[{""codename"": ""project_editor"", ""model"": ""promgen.project"", ""obj_pk"": 1}]",POST,api-v2:farm-hosts,"{""id"": 1}","{""hosts"": [""new.example.com"", ""example.com""]}",204,"{""exists"": [{""model"": ""promgen.host"", ""filters"": {""farm_id"": 1, ""name"": ""new.example.com""}, ""value"": true}]}"
+An editor can delete a farm host.,demo,"[{""codename"": ""project_editor"", ""model"": ""promgen.project"", ""obj_pk"": 1}]",DELETE,api-v2:farm-host,"{""id"": 1, ""host_id"": 1}",,204,"{""exists"": [{""model"": ""promgen.host"", ""filters"": {""farm_id"": 1, ""name"": ""new.example.com""}, ""value"": false}]}"
+An editor can sync a remote farm.,demo,"[{""codename"": ""project_editor"", ""model"": ""promgen.project"", ""obj_pk"": 2}]",POST,api-v2:farm-sync,"{""id"": 2}",,200,
+An editor can convert a remote farm to a local farm.,demo,"[{""codename"": ""project_editor"", ""model"": ""promgen.project"", ""obj_pk"": 2}]",POST,api-v2:farm-convert-to-local-farm,"{""id"": 2}",,200,
+An editor cannot sync a local farm.,demo,"[{""codename"": ""project_editor"", ""model"": ""promgen.project"", ""obj_pk"": 1}]",POST,api-v2:farm-sync,"{""id"": 1}",,400,
+An editor cannot convert a local farm to a local farm.,demo,"[{""codename"": ""project_editor"", ""model"": ""promgen.project"", ""obj_pk"": 1}]",POST,api-v2:farm-convert-to-local-farm,"{""id"": 1}",,400,
+An editor can delete a local farm.,demo,"[{""codename"": ""project_editor"", ""model"": ""promgen.project"", ""obj_pk"": 1}]",DELETE,api-v2:farm-detail,"{""id"": 1}",,204,

--- a/promgen/tests/examples/rest.farm.1.json
+++ b/promgen/tests/examples/rest.farm.1.json
@@ -5,8 +5,8 @@
   "source": "promgen",
   "hosts": [
     {
-      "name": "host.example.com",
-      "url": "http://promgen.example.com/host/host.example.com"
+      "name": "example.com",
+      "url": "http://promgen.example.com/host/example.com"
     }
   ],
   "project": 1

--- a/promgen/tests/examples/rest.farm.detail.json
+++ b/promgen/tests/examples/rest.farm.detail.json
@@ -1,0 +1,8 @@
+{
+  "id": 1,
+  "project": "test-project",
+  "project_id": 1,
+  "name": "test-farm",
+  "source": "promgen",
+  "remote": false
+}

--- a/promgen/tests/examples/rest.farm.hosts.json
+++ b/promgen/tests/examples/rest.farm.hosts.json
@@ -1,0 +1,12 @@
+{
+  "count": 1,
+  "next": null,
+  "previous": null,
+  "results": [
+    {
+      "farm": 1,
+      "id": 1,
+      "name": "example.com"
+    }
+  ]
+}

--- a/promgen/tests/examples/rest.farm.list.json
+++ b/promgen/tests/examples/rest.farm.list.json
@@ -1,0 +1,23 @@
+{
+  "count": 2,
+  "next": null,
+  "previous": null,
+  "results": [
+    {
+      "id": 2,
+      "project": "another-project",
+      "project_id": 2,
+      "name": "other-farm",
+      "source": "external",
+      "remote": true
+    },
+    {
+      "id": 1,
+      "project": "test-project",
+      "project_id": 1,
+      "name": "test-farm",
+      "source": "promgen",
+      "remote": false
+    }
+  ]
+}

--- a/promgen/tests/test_host_add.py
+++ b/promgen/tests/test_host_add.py
@@ -25,7 +25,7 @@ class HostTests(PromgenTest):
             {"hosts": "\naaa.example.com\nbbb.example.com\nccc.example.com \n"},
             follow=False,
         )
-        self.assertCount(models.Host, 3, "Expected 3 hosts")
+        self.assertCount(models.Host, 4, "Expected 4 hosts (Fixture has one host)")
 
     def test_comma(self):
         assign_perm(
@@ -36,7 +36,7 @@ class HostTests(PromgenTest):
             {"hosts": ",,aaa.example.com, bbb.example.com,ccc.example.com,"},
             follow=False,
         )
-        self.assertCount(models.Host, 3, "Expected 3 hosts")
+        self.assertCount(models.Host, 4, "Expected 4 hosts (Fixture has one host)")
 
     # Within our new host code, the hosts are split (by newline or comma) and then
     # individually tested. Here we will test our validator on specific entries that

--- a/promgen/tests/test_rest.py
+++ b/promgen/tests/test_rest.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2018 LINE Corporation
 # These sources are released under the terms of the MIT license: see LICENSE
 import json
+from unittest import mock
 
 from django.apps import apps as django_apps
 from django.contrib.auth.models import Permission, User
@@ -11,7 +12,7 @@ from guardian.models import UserObjectPermission
 from guardian.shortcuts import assign_perm, remove_perm
 from rest_framework.authtoken.models import Token
 
-from promgen import models, rest, signals, tests
+from promgen import models, plugins, rest, signals, tests
 from promgen.notification.email import NotificationEmail
 
 
@@ -225,3 +226,27 @@ class RestAPITest(tests.PromgenTest):
         cases = tests.Data("cases", "test_rest_rule.csv").csv()
         for case in cases:
             self._run_rest_test(case)
+
+    def test_rest_farm(self):
+        local_driver = mock.Mock(remote=False)
+        local_driver.name = "promgen"
+        local_driver.load.return_value = mock.Mock(return_value=mock.Mock(remote=False))
+        remote_driver = mock.Mock(remote=True)
+        remote_driver.name = "external"
+        remote_driver.load.return_value = mock.Mock(return_value=mock.Mock(remote=True))
+        with (
+            mock.patch.object(plugins, "discovery", return_value=[local_driver, remote_driver]),
+            mock.patch.object(
+                models.Farm,
+                "driver_set",
+                return_value=[
+                    (local_driver.name, local_driver),
+                    (remote_driver.name, remote_driver),
+                ],
+            ),
+            mock.patch.object(models.Farm, "fetch", return_value=["other-farm", "other-farm-2"]),
+            mock.patch.object(models.Farm, "refresh", return_value=(set(), set())),
+        ):
+            cases = tests.Data("cases", "test_rest_farm.csv").csv()
+            for case in cases:
+                self._run_rest_test(case)

--- a/promgen/tests/test_rest.py
+++ b/promgen/tests/test_rest.py
@@ -157,13 +157,10 @@ class RestAPITest(tests.PromgenTest):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 0)
 
-        # Check retrieving farms with a non-existent "source" returns an empty list
+        # Check retrieving farms with a non-existent "source" returns 400 Bad Request
         response = self.client.get(reverse("api:farm-list"), {"source": "other-source"})
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(response.data), 0)
+        self.assertEqual(response.status_code, 400)
 
-        farm = models.Farm.objects.get(id=1)
-        models.Host.objects.create(name="host.example.com", farm=farm)
         expected = tests.Data("examples", "rest.farm.1.json").json()
 
         # Check retrieving the farm whose "id" is "1", including the list of hosts.

--- a/promgen/tests/test_routes.py
+++ b/promgen/tests/test_routes.py
@@ -32,7 +32,7 @@ class RouteTests(tests.PromgenTest):
         self.assertCount(models.Service, 3, "Import one service (Fixture has two services)")
         self.assertCount(models.Project, 4, "Import two projects")
         self.assertCount(models.Exporter, 4, "Import two more exporters")
-        self.assertCount(models.Host, 3, "Import three hosts")
+        self.assertCount(models.Host, 4, "Import three hosts (Fixture has one host)")
 
     @override_settings(PROMGEN=TEST_SETTINGS)
     @override_settings(CELERY_TASK_ALWAYS_EAGER=True)
@@ -53,9 +53,9 @@ class RouteTests(tests.PromgenTest):
         self.assertCount(models.Project, 4, "Import two projects (Fixture has 2 projectsa)")
         self.assertCount(models.Exporter, 4, "Import two more exporters")
         self.assertCount(
-            models.Farm, 3, "Original one farm and one updated farm (fixture has one farm)"
+            models.Farm, 4, "Original three farms and one new farm (fixture has two farms)"
         )
-        self.assertCount(models.Host, 5, "Original 3 hosts and two new ones")
+        self.assertCount(models.Host, 6, "Original 4 hosts and two new ones")
 
     @mock.patch("requests.get")
     def test_scrape(self, mock_get):

--- a/promgen/urls.py
+++ b/promgen/urls.py
@@ -34,6 +34,7 @@ v2_router = rest_v2.Router(trailing_slash=False)
 v2_router.register("logs", rest_v2.AuditViewSet)
 v2_router.register("notifiers", rest_v2.NotifierViewSet)
 v2_router.register("rules", rest_v2.RuleViewSet)
+v2_router.register("farms", rest_v2.FarmViewSet)
 
 urlpatterns = [
     path("admin/", admin.site.urls),


### PR DESCRIPTION
We have added several APIs to support users integrating with Promgen's Farms:
- List and filter Farms.
- List Farm sources.
- List remote Farm by source.
- Retrieve detail information of an existing Farm.
- List Hosts of an existing Farm.
- Update/Partially update an existing Farm.
- Delete an existing Farm.
- Sync an existing remote Farm.
- Convert an existing remote Farm to local Farm.