### PR TITLE
Add new APIs for integrating with Exporter

### DIFF
--- a/promgen/filters.py
+++ b/promgen/filters.py
@@ -174,3 +174,34 @@ class RuleFilterV2(django_filters.rest_framework.FilterSet):
         method=filter_content_type,
         help_text="Filter by content type model name. Example: content_type=service",
     )
+
+
+class ExporterFilter(django_filters.rest_framework.FilterSet):
+    project_id = django_filters.NumberFilter(
+        field_name="project__id",
+        lookup_expr="exact",
+        help_text="Filter by exact project ID. Example: project_id=123.",
+    )
+    job = django_filters.CharFilter(
+        field_name="job",
+        lookup_expr="contains",
+        help_text="Filter by job name containing a specific substring. Example: job=prometheus",
+    )
+    path = django_filters.CharFilter(
+        field_name="path",
+        lookup_expr="contains",
+        help_text="Filter by path containing a specific substring. Example: path=/metrics",
+    )
+    scheme = django_filters.ChoiceFilter(
+        field_name="scheme",
+        choices=[
+            ("http", "HTTP"),
+            ("https", "HTTPS"),
+        ],
+        lookup_expr="exact",
+        help_text="Filter by exact scheme. Example: scheme=http",
+    )
+    enabled = django_filters.BooleanFilter(
+        field_name="enabled",
+        help_text="Filter by enabled status (true or false). Example: enabled=true",
+    )

--- a/promgen/fixtures/testcases.yaml
+++ b/promgen/fixtures/testcases.yaml
@@ -85,13 +85,15 @@
     project: 1
     job: node
     port: 9100
+    path: /metrics
 - model: promgen.exporter
   pk: 2
   fields:
     project: 2
-    job: node
+    job: nginx
     port: 9100
     enabled: false
+    scheme: https
 - model: promgen.probe
   pk: 1
   fields:

--- a/promgen/rest_v2.py
+++ b/promgen/rest_v2.py
@@ -472,3 +472,38 @@ class FarmViewSet(
         farm.source = discovery.FARM_DEFAULT
         farm.save()
         return Response(serializers.FarmRetrieveSerializer(farm).data)
+
+
+@extend_schema_view(
+    list=extend_schema(summary="List Exporters", description="Retrieve a list of all exporters."),
+    retrieve=extend_schema(
+        summary="Retrieve Exporter",
+        description="Retrieve detailed information about a specific exporter.",
+    ),
+    update=extend_schema(summary="Update Exporter", description="Update an existing exporter."),
+    partial_update=extend_schema(
+        summary="Partially Update Exporter", description="Partially update an existing exporter."
+    ),
+    destroy=extend_schema(summary="Delete Exporter", description="Delete an existing exporter."),
+)
+@extend_schema(tags=["Exporter"])
+class ExporterViewSet(
+    mixins.RetrieveModelMixin,
+    mixins.ListModelMixin,
+    mixins.UpdateModelMixin,
+    mixins.DestroyModelMixin,
+    viewsets.GenericViewSet,
+):
+    queryset = models.Exporter.objects.all()
+    filterset_class = filters.ExporterFilter
+    serializer_class = serializers.ExporterRetrieveSerializer
+    lookup_value_regex = "[^/]+"
+    lookup_field = "id"
+    pagination_class = PromgenPagination
+    permission_classes = [permissions.PromgenGuardianRestPermission]
+
+    def get_queryset(self):
+        if self.request.user.is_superuser or self.action != "list":
+            return self.queryset
+        accessible_projects = permissions.get_accessible_projects_for_user(self.request.user)
+        return self.queryset.filter(project__in=accessible_projects)

--- a/promgen/serializers.py
+++ b/promgen/serializers.py
@@ -282,3 +282,13 @@ class FarmSourceSerializer(serializers.Serializer):
 
 class RemoteFarmSerializer(serializers.Serializer):
     name = serializers.CharField()
+
+
+class ExporterRetrieveSerializer(serializers.ModelSerializer):
+    project = serializers.ReadOnlyField(source="project.name")
+    project_id = serializers.ReadOnlyField(source="project.id")
+
+    class Meta:
+        model = models.Exporter
+        fields = "__all__"
+        read_only_fields = ("job", "port", "path", "scheme", "project")

--- a/promgen/tests/cases/test_rest_exporter.csv
+++ b/promgen/tests/cases/test_rest_exporter.csv
@@ -1,0 +1,26 @@
+case,user,permissions,method,viewname,kwargs,payload,expected_status,expected_response
+An unauthenticated user cannot list exporters.,,,GET,api-v2:exporter-list,,,401,
+An unauthenticated user cannot view exporter detail.,,,GET,api-v2:exporter-detail,"{""id"": 1}",,401,
+An unauthenticated user cannot update an exporter.,,,PUT,api-v2:exporter-detail,"{""id"": 1}",,401,
+An unauthenticated user cannot partially update an exporter.,,,PATCH,api-v2:exporter-detail,"{""id"": 1}",,401,
+An unauthenticated user cannot delete an exporter.,,,DELETE,api-v2:exporter-detail,"{""id"": 1}",,401,
+An authenticated user without permissions sees no exporters.,demo,,GET,api-v2:exporter-list,,,200,"{""count"": 0}"
+An authenticated user without permissions cannot view exporter detail.,demo,,GET,api-v2:exporter-detail,"{""id"": 1}",,403,
+An authenticated user without permissions cannot update an exporter.,demo,,PUT,api-v2:exporter-detail,"{""id"": 1}",,403,
+An authenticated user without permissions cannot partially update an exporter.,demo,,PATCH,api-v2:exporter-detail,"{""id"": 1}",,403,
+An authenticated user without permissions cannot delete an exporter.,demo,,DELETE,api-v2:exporter-detail,"{""id"": 1}",,403,
+A viewer can list exporters.,demo,"[{""codename"": ""project_viewer"", ""model"": ""promgen.project"", ""obj_pk"": 1}, {""codename"": ""project_viewer"", ""model"": ""promgen.project"", ""obj_pk"": 2}]",GET,api-v2:exporter-list,,,200,"{""example"": ""rest.exporter.list.json""}"
+A viewer can get paginated exporter results.,demo,"[{""codename"": ""project_viewer"", ""model"": ""promgen.project"", ""obj_pk"": 1}, {""codename"": ""project_viewer"", ""model"": ""promgen.project"", ""obj_pk"": 2}]",GET,api-v2:exporter-list,,"{""page_number"": 1, ""page_size"": 1}",200,"{""results_length"": 1}"
+A viewer can filter exporters by enabled state.,demo,"[{""codename"": ""project_viewer"", ""model"": ""promgen.project"", ""obj_pk"": 1}, {""codename"": ""project_viewer"", ""model"": ""promgen.project"", ""obj_pk"": 2}]",GET,api-v2:exporter-list,,"{""enabled"": ""true""}",200,"{""count"": 1}"
+A viewer can filter exporters by job.,demo,"[{""codename"": ""project_viewer"", ""model"": ""promgen.project"", ""obj_pk"": 1}, {""codename"": ""project_viewer"", ""model"": ""promgen.project"", ""obj_pk"": 2}]",GET,api-v2:exporter-list,,"{""job"": ""inx""}",200,"{""count"": 1}"
+A viewer can filter exporters by path.,demo,"[{""codename"": ""project_viewer"", ""model"": ""promgen.project"", ""obj_pk"": 1}, {""codename"": ""project_viewer"", ""model"": ""promgen.project"", ""obj_pk"": 2}]",GET,api-v2:exporter-list,,"{""path"": ""/metrics""}",200,"{""count"": 1}"
+A viewer can filter exporters by project ID.,demo,"[{""codename"": ""project_viewer"", ""model"": ""promgen.project"", ""obj_pk"": 1}, {""codename"": ""project_viewer"", ""model"": ""promgen.project"", ""obj_pk"": 2}]",GET,api-v2:exporter-list,,"{""project_id"": 1}",200,"{""count"": 1}"
+A viewer can filter exporters by scheme.,demo,"[{""codename"": ""project_viewer"", ""model"": ""promgen.project"", ""obj_pk"": 1}, {""codename"": ""project_viewer"", ""model"": ""promgen.project"", ""obj_pk"": 2}]",GET,api-v2:exporter-list,,"{""scheme"": ""https""}",200,"{""count"": 1}"
+Invalid exporter scheme returns HTTP 400.,demo,"[{""codename"": ""project_viewer"", ""model"": ""promgen.project"", ""obj_pk"": 1}, {""codename"": ""project_viewer"", ""model"": ""promgen.project"", ""obj_pk"": 2}]",GET,api-v2:exporter-list,,"{""scheme"": ""non-existent""}",400,
+A viewer can view exporter detail.,demo,"[{""codename"": ""project_viewer"", ""model"": ""promgen.project"", ""obj_pk"": 1}]",GET,api-v2:exporter-detail,"{""id"": 1}",,200,"{""example"": ""rest.exporter.detail.json""}"
+A viewer cannot update an exporter.,demo,"[{""codename"": ""project_viewer"", ""model"": ""promgen.project"", ""obj_pk"": 1}]",PUT,api-v2:exporter-detail,"{""id"": 1}",,403,
+A viewer cannot partially update an exporter.,demo,"[{""codename"": ""project_viewer"", ""model"": ""promgen.project"", ""obj_pk"": 1}]",PATCH,api-v2:exporter-detail,"{""id"": 1}",,403,
+A viewer cannot delete an exporter.,demo,"[{""codename"": ""project_viewer"", ""model"": ""promgen.project"", ""obj_pk"": 1}]",DELETE,api-v2:exporter-detail,"{""id"": 1}",,403,
+An editor can update an exporter.,demo,"[{""codename"": ""project_editor"", ""model"": ""promgen.project"", ""obj_pk"": 1}]",PUT,api-v2:exporter-detail,"{""id"": 1}","{""enabled"": true}",200,
+An editor can partially update an exporter.,demo,"[{""codename"": ""project_editor"", ""model"": ""promgen.project"", ""obj_pk"": 1}]",PATCH,api-v2:exporter-detail,"{""id"": 1}","{""enabled"": true}",200,
+An editor can delete an exporter.,demo,"[{""codename"": ""project_editor"", ""model"": ""promgen.project"", ""obj_pk"": 1}]",DELETE,api-v2:exporter-detail,"{""id"": 1}",,204,

--- a/promgen/tests/examples/export.targets.json
+++ b/promgen/tests/examples/export.targets.json
@@ -2,6 +2,7 @@
     {
       "labels": {
         "__farm_source": "promgen",
+        "__metrics_path__": "/metrics",
         "__scheme__": "http",
         "__shard": "test-shard",
         "farm": "test-farm",

--- a/promgen/tests/examples/rest.exporter.detail.json
+++ b/promgen/tests/examples/rest.exporter.detail.json
@@ -1,0 +1,10 @@
+{
+  "enabled": true,
+  "id": 1,
+  "job": "node",
+  "path": "/metrics",
+  "port": 9100,
+  "project": "test-project",
+  "project_id": 1,
+  "scheme": "http"
+}

--- a/promgen/tests/examples/rest.exporter.list.json
+++ b/promgen/tests/examples/rest.exporter.list.json
@@ -1,0 +1,27 @@
+{
+  "count": 2,
+  "next": null,
+  "previous": null,
+  "results": [
+    {
+      "enabled": false,
+      "id": 2,
+      "job": "nginx",
+      "path": "",
+      "port": 9100,
+      "project": "another-project",
+      "project_id": 2,
+      "scheme": "https"
+    },
+    {
+      "enabled": true,
+      "id": 1,
+      "job": "node",
+      "path": "/metrics",
+      "port": 9100,
+      "project": "test-project",
+      "project_id": 1,
+      "scheme": "http"
+    }
+  ]
+}

--- a/promgen/tests/test_rest.py
+++ b/promgen/tests/test_rest.py
@@ -250,3 +250,9 @@ class RestAPITest(tests.PromgenTest):
             cases = tests.Data("cases", "test_rest_farm.csv").csv()
             for case in cases:
                 self._run_rest_test(case)
+
+    @override_settings(PROMGEN=tests.SETTINGS)
+    def test_rest_exporter(self):
+        cases = tests.Data("cases", "test_rest_exporter.csv").csv()
+        for case in cases:
+            self._run_rest_test(case)

--- a/promgen/urls.py
+++ b/promgen/urls.py
@@ -35,6 +35,7 @@ v2_router.register("logs", rest_v2.AuditViewSet)
 v2_router.register("notifiers", rest_v2.NotifierViewSet)
 v2_router.register("rules", rest_v2.RuleViewSet)
 v2_router.register("farms", rest_v2.FarmViewSet)
+v2_router.register("exporters", rest_v2.ExporterViewSet)
 
 urlpatterns = [
     path("admin/", admin.site.urls),


### PR DESCRIPTION
We have added several APIs to support users integrating with Promgen's Exporters:
- List and filter Exporters.
- Retrieve detail information of an existing Exporter.
- Update/Partially update an existing Exporter.
- Delete an existing Exporter.