### PR TITLE
Update notifier API to return both value and alias fields

### DIFF
--- a/promgen/serializers.py
+++ b/promgen/serializers.py
@@ -198,14 +198,17 @@ class NotifierSerializer(serializers.ModelSerializer):
     content_name = serializers.SerializerMethodField()
     content_type = serializers.ReadOnlyField(source="content_type.model")
     filters = FilterSerializer(many=True, read_only=True, source="filter_set")
-    value = serializers.ReadOnlyField(source="show_value")
+    value = serializers.SerializerMethodField(
+        method_name="get_notifier_value",
+        help_text="If an alias is set, the value will be hidden as null.",
+    )
+    alias = serializers.CharField(
+        help_text="Use to hide the notifier's value from being displayed."
+    )
 
     class Meta:
         model = models.Sender
-        exclude = (
-            "object_id",
-            "alias",
-        )
+        exclude = ("object_id",)
 
     def get_content_name(self, obj) -> str:
         if hasattr(obj, "content_object"):
@@ -214,6 +217,11 @@ class NotifierSerializer(serializers.ModelSerializer):
             if hasattr(obj.content_object, "username"):
                 return obj.content_object.username
         return None
+
+    def get_notifier_value(self, obj) -> str:
+        if obj.alias:
+            return None
+        return obj.value
 
 
 class UpdateNotifierSerializer(serializers.ModelSerializer):

--- a/promgen/tests/examples/rest.notifier.list.json
+++ b/promgen/tests/examples/rest.notifier.list.json
@@ -17,7 +17,8 @@
       "id": 1,
       "owner": "admin",
       "sender": "promgen.notification.email",
-      "value": "email@example.com"
+      "value": "email@example.com",
+      "alias": ""
     },
     {
       "content_name": "test-project",
@@ -27,7 +28,8 @@
       "id": 2,
       "owner": "demo",
       "sender": "promgen.notification.slack",
-      "value": "https://hooks.slack.com/services/XXXXXXXXX/XXXXXXXXX/XXXXXXXXXXXXXXXXXXXXXXXX"
+      "value": "https://hooks.slack.com/services/XXXXXXXXX/XXXXXXXXX/XXXXXXXXXXXXXXXXXXXXXXXX",
+      "alias": ""
     }
   ]
 }

--- a/promgen/tests/test_rest.py
+++ b/promgen/tests/test_rest.py
@@ -215,10 +215,14 @@ class RestAPITest(tests.PromgenTest):
             1,
             "Expected one notifier matching the filter after alias is set",
         )
-        self.assertEqual(
+        self.assertIsNone(
             response.data["results"][0]["value"],
+            "Expected the notifier's value to be null",
+        )
+        self.assertEqual(
+            response.data["results"][0]["alias"],
             "alias",
-            "Expected the notifier's value to match the alias",
+            "Expected the notifier's alias to match the alias",
         )
 
     @override_settings(PROMGEN=tests.SETTINGS)


### PR DESCRIPTION
Previously, the retrieving notifier API only responded with the "value" field. If a notifier had an "alias", the "value" field would return the alias, which could be ambiguous for users. To improve clarity, we have updated to always return both "value" and "alias" fields.  When an "alias" exists, the "value" field will be set to null.