### PR TITLE
Add new APIs for integrating with URL

### DIFF
--- a/promgen/filters.py
+++ b/promgen/filters.py
@@ -205,3 +205,32 @@ class ExporterFilter(django_filters.rest_framework.FilterSet):
         field_name="enabled",
         help_text="Filter by enabled status (true or false). Example: enabled=true",
     )
+
+
+class ProbeChoices:
+    def __iter__(self):
+        return iter(models.Probe.objects.values_list("module", "description"))
+
+    def __len__(self):
+        return models.Probe.objects.values("module").count()
+
+
+class URLFilter(django_filters.rest_framework.FilterSet):
+    project_id = django_filters.NumberFilter(
+        field_name="project__id",
+        lookup_expr="exact",
+        help_text="Filter by exact project ID. Example: project_id=123.",
+    )
+    probe = django_filters.ChoiceFilter(
+        field_name="probe__module",
+        choices=ProbeChoices(),
+        help_text="Filter by exact probe scheme. Example: probe=http_2xx",
+    )
+
+
+class ProbeFilter(django_filters.rest_framework.FilterSet):
+    module = django_filters.CharFilter(
+        field_name="module",
+        lookup_expr="contains",
+        help_text="Filter by probe module containing a specific substring. Example: probe=http_2xx",
+    )

--- a/promgen/fixtures/testcases.yaml
+++ b/promgen/fixtures/testcases.yaml
@@ -98,12 +98,22 @@
   pk: 1
   fields:
     module: fixture_test
+- model: promgen.probe
+  pk: 2
+  fields:
+    module: http_2xx
 - model: promgen.url
   pk: 1
   fields:
     project: 1
     probe: 1
     url: probe.example.com
+- model: promgen.url
+  pk: 2
+  fields:
+    project: 2
+    probe: 2
+    url: probe-2.example.com
 - model: promgen.audit
   pk: 1
   fields:

--- a/promgen/rest_v2.py
+++ b/promgen/rest_v2.py
@@ -507,3 +507,37 @@ class ExporterViewSet(
             return self.queryset
         accessible_projects = permissions.get_accessible_projects_for_user(self.request.user)
         return self.queryset.filter(project__in=accessible_projects)
+
+
+@extend_schema_view(
+    list=extend_schema(summary="List URLs", description="Retrieve a list of all URLs."),
+    destroy=extend_schema(summary="Delete URL", description="Delete an existing URL."),
+)
+@extend_schema(tags=["URL"])
+class URLViewSet(mixins.ListModelMixin, mixins.DestroyModelMixin, viewsets.GenericViewSet):
+    queryset = models.URL.objects.all()
+    filterset_class = filters.URLFilter
+    serializer_class = serializers.URLSerializer
+    lookup_value_regex = "[^/]+"
+    lookup_field = "id"
+    pagination_class = PromgenPagination
+    permission_classes = [permissions.PromgenGuardianRestPermission]
+
+    def get_queryset(self):
+        if self.request.user.is_superuser or self.action != "list":
+            return self.queryset
+        accessible_projects = permissions.get_accessible_projects_for_user(self.request.user)
+        return self.queryset.filter(project__in=accessible_projects)
+
+
+@extend_schema_view(
+    list=extend_schema(summary="List Probes", description="Retrieve a list of all Probes."),
+)
+@extend_schema(tags=["URL"])
+class ProbeViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
+    queryset = models.Probe.objects.all()
+    filterset_class = filters.ProbeFilter
+    serializer_class = serializers.ProbeSerializer
+    lookup_value_regex = "[^/]+"
+    pagination_class = PromgenPagination
+    permission_classes = [permissions.ReadOnlyForAuthenticatedUserOrIsSuperuser]

--- a/promgen/serializers.py
+++ b/promgen/serializers.py
@@ -300,3 +300,18 @@ class ExporterRetrieveSerializer(serializers.ModelSerializer):
         model = models.Exporter
         fields = "__all__"
         read_only_fields = ("job", "port", "path", "scheme", "project")
+
+
+class URLSerializer(serializers.ModelSerializer):
+    project = serializers.ReadOnlyField(source="project.name")
+    probe = serializers.ReadOnlyField(source="probe.module")
+
+    class Meta:
+        model = models.URL
+        fields = "__all__"
+
+
+class ProbeSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = models.Probe
+        fields = "__all__"

--- a/promgen/tests/cases/test_rest_url.csv
+++ b/promgen/tests/cases/test_rest_url.csv
@@ -1,0 +1,15 @@
+case,user,permissions,method,viewname,kwargs,payload,expected_status,expected_response
+An unauthenticated user cannot list urls.,,,GET,api-v2:url-list,,,401,
+An unauthenticated user cannot list url probes.,,,GET,api-v2:probe-list,,,401,
+An unauthenticated user cannot delete a url.,,,DELETE,api-v2:url-detail,"{""id"": 1}",,401,
+An authenticated user without permissions sees no urls.,demo,,GET,api-v2:url-list,,,200,"{""count"": 0}"
+An authenticated user without permissions can see url probes.,demo,,GET,api-v2:probe-list,,,200,"{""count"": 2}"
+An authenticated user without permissions can get paginated probes results.,demo,,GET,api-v2:probe-list,,"{""page_number"": 2, ""page_size"": 1}",200,"{""results_length"": 1}"
+An authenticated user without permissions can filter probes by module name.,demo,,GET,api-v2:probe-list,,"{""module"": ""http""}",200,"{""results_length"": 1}"
+An authenticated user without permissions cannot delete a url.,demo,,DELETE,api-v2:url-detail,"{""id"": 1}",,403,
+A viewer can list urls.,demo,"[{""codename"": ""project_viewer"", ""model"": ""promgen.project"", ""obj_pk"": 1}, {""codename"": ""project_viewer"", ""model"": ""promgen.project"", ""obj_pk"": 2}]",GET,api-v2:url-list,,,200,"{""example"": ""rest.url.list.json""}"
+A viewer can get paginated url results.,demo,"[{""codename"": ""project_viewer"", ""model"": ""promgen.project"", ""obj_pk"": 1}, {""codename"": ""project_viewer"", ""model"": ""promgen.project"", ""obj_pk"": 2}]",GET,api-v2:url-list,,"{""page_number"": 2, ""page_size"": 1}",200,"{""results_length"": 1}"
+A viewer can filter urls by probe.,demo,"[{""codename"": ""project_viewer"", ""model"": ""promgen.project"", ""obj_pk"": 1}, {""codename"": ""project_viewer"", ""model"": ""promgen.project"", ""obj_pk"": 2}]",GET,api-v2:url-list,,"{""probe"": ""fixture_test""}",200,"{""results_length"": 1}"
+A viewer can filter urls by project ID.,demo,"[{""codename"": ""project_viewer"", ""model"": ""promgen.project"", ""obj_pk"": 1}, {""codename"": ""project_viewer"", ""model"": ""promgen.project"", ""obj_pk"": 2}]",GET,api-v2:url-list,,"{""project_id"": 1}",200,"{""results_length"": 1}"
+A viewer cannot delete a url.,demo,"[{""codename"": ""project_viewer"", ""model"": ""promgen.project"", ""obj_pk"": 1}]",DELETE,api-v2:url-detail,"{""id"": 1}",,403,
+An editor can delete a url.,demo,"[{""codename"": ""project_editor"", ""model"": ""promgen.project"", ""obj_pk"": 1}]",DELETE,api-v2:url-detail,"{""id"": 1}",,204,

--- a/promgen/tests/examples/export.urls.json
+++ b/promgen/tests/examples/export.urls.json
@@ -1,12 +1,26 @@
 [
   {
     "labels": {
+      "__param_module": "http_2xx",
+      "__shard": "test-shard",
+      "job": "http_2xx",
+      "project": "another-project",
+      "service": "test-service"
+    },
+    "targets": [
+      "probe-2.example.com"
+    ]
+  },
+  {
+    "labels": {
       "__param_module": "fixture_test",
       "__shard": "test-shard",
       "job": "fixture_test",
       "project": "test-project",
       "service": "test-service"
     },
-    "targets": ["probe.example.com"]
+    "targets": [
+      "probe.example.com"
+    ]
   }
 ]

--- a/promgen/tests/examples/rest.url.list.json
+++ b/promgen/tests/examples/rest.url.list.json
@@ -1,0 +1,19 @@
+{
+  "count": 2,
+  "next": null,
+  "previous": null,
+  "results": [
+    {
+      "id": 2,
+      "probe": "http_2xx",
+      "project": "another-project",
+      "url": "probe-2.example.com"
+    },
+    {
+      "id": 1,
+      "probe": "fixture_test",
+      "project": "test-project",
+      "url": "probe.example.com"
+    }
+  ]
+}

--- a/promgen/tests/test_rest.py
+++ b/promgen/tests/test_rest.py
@@ -260,3 +260,9 @@ class RestAPITest(tests.PromgenTest):
         cases = tests.Data("cases", "test_rest_exporter.csv").csv()
         for case in cases:
             self._run_rest_test(case)
+
+    @override_settings(PROMGEN=tests.SETTINGS)
+    def test_rest_url(self):
+        cases = tests.Data("cases", "test_rest_url.csv").csv()
+        for case in cases:
+            self._run_rest_test(case)

--- a/promgen/urls.py
+++ b/promgen/urls.py
@@ -36,6 +36,8 @@ v2_router.register("notifiers", rest_v2.NotifierViewSet)
 v2_router.register("rules", rest_v2.RuleViewSet)
 v2_router.register("farms", rest_v2.FarmViewSet)
 v2_router.register("exporters", rest_v2.ExporterViewSet)
+v2_router.register("urls", rest_v2.URLViewSet)
+v2_router.register("probes", rest_v2.ProbeViewSet)
 
 urlpatterns = [
     path("admin/", admin.site.urls),


### PR DESCRIPTION
We have added several APIs to support users integrating with Promgen's URL:
- List and filter URLs.
- List and filter URL Probes.
- Delete an existing URL.