### PR TITLE
Add Django SRI

### DIFF
--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -52,6 +52,7 @@ django==4.2.26
     # via
     #   django-filter
     #   django-guardian
+    #   django-sri
     #   djangorestframework
     #   drf-spectacular
     #   promgen (pyproject.toml)
@@ -61,6 +62,8 @@ django-environ==0.10.0
 django-filter==23.2
     # via promgen (pyproject.toml)
 django-guardian==3.0.0
+    # via promgen (pyproject.toml)
+django-sri==0.8.0
     # via promgen (pyproject.toml)
 djangorestframework==3.14.0
     # via

--- a/promgen/settings.py
+++ b/promgen/settings.py
@@ -64,6 +64,7 @@ INSTALLED_APPS = apps_from_setuptools + [
     "rest_framework.authtoken",
     "rest_framework",
     "social_django",
+    "sri",
     "guardian",
     # Django
     "django.forms",

--- a/promgen/templates/base.html
+++ b/promgen/templates/base.html
@@ -1,3 +1,4 @@
+{% load sri %}
 {% load static %}
 <!DOCTYPE html>
 <html>
@@ -6,12 +7,17 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title v-pre>{% block title %}Promgen {{ VERSION }}{% endblock %}</title>
-  <link rel="stylesheet" href="{% static 'css/bootstrap.min.css' %}">
-  <link rel="stylesheet" href="{% static 'css/bootstrap-theme.min.css' %}">
-  <link rel="stylesheet" href="{% static 'css/bootstrap-switch.min.css' %}">
-  <link rel="stylesheet" href="{% static 'css/promgen.css' %}?v=2">
-  <link rel="stylesheet" href="{% static 'css/select2-4.1.0-rc.0.min.css' %}">
-  <link rel="icon" href="{% static 'images/promgen_logo_color.png' %}">
+  {% sri_static "css/bootstrap.min.css" %}
+  {% sri_static "css/bootstrap-theme.min.css" %}
+  {% sri_static "css/bootstrap-switch.min.css" %}
+  <link
+    rel="stylesheet"
+    href="{% static 'css/promgen.css' %}?v=2"
+    integrity="{% sri_integrity_static 'css/promgen.css' %}"
+    crossorigin="anonymous"
+  >
+  {% sri_static "css/select2-4.1.0-rc.0.min.css" %}
+  {% sri_static "images/promgen_logo_color.png" rel="icon" %}
 </head>
 
 <body>
@@ -31,17 +37,17 @@
       {% block content %}{% endblock %}
     </div>
   </div>
-  <script src="{% static 'js/jquery.min.js' %}"></script>
-  <script src="{% static 'js/bootstrap.min.js' %}"></script>
-  <script src="{% static 'js/bootstrap-switch.min.js' %}"></script>
-  <script src="{% static 'js/luxon.min.js' %}"></script>
-  <script src="{% static 'js/linkify.min.js' %}"></script>
-  <script src="{% static 'js/linkify-string.min.js' %}"></script>
-  <script src="{% static 'js/select2-4.1.0-rc.0.min.js' %}"></script>
+  {% sri_static "js/jquery.min.js" %}
+  {% sri_static "js/bootstrap.min.js" %}
+  {% sri_static "js/bootstrap-switch.min.js" %}
+  {% sri_static "js/luxon.min.js" %}
+  {% sri_static "js/linkify.min.js" %}
+  {% sri_static "js/linkify-string.min.js" %}
+  {% sri_static "js/select2-4.1.0-rc.0.min.js" %}
   {% if debug %}
-  <script src="{% static 'js/vue-3.3.7/vue.global.js' %}"></script>
+  {% sri_static "js/vue-3.3.7/vue.global.js" %}
   {% else %}
-  <script src="{% static 'js/vue-3.3.7/vue.global.prod.js' %}"></script>
+  {% sri_static "js/vue-3.3.7/vue.global.prod.js" %}
   {% endif %}
   <script type="text/x-template" id="bootstrap-panel-template">
     {% include 'promgen/vue/bootstrap_panel.html' %}
@@ -64,15 +70,22 @@
   <script type="text/x-template" id="silence-list-modal-template">
     {% include 'promgen/vue/silence_list_modal.html' %}
   </script>
-  <script src="{% static 'js/promgen.js' %}?v=6"></script>
-  <script src="{% static 'js/mixins.vue.js' %}"></script>
-  <script src="{% static 'js/promgen.vue.js' %}?v=7"></script>
   <script
-    type="module"
-    src="{% static 'js/rapidoc-9.3.8/rapidoc.min.js' %}"
-    integrity="sha384-P1PDwOI8/EjWKOcUzoOPC8znymPv5cye5e7Htif9XHt3CbmSPkKvyPYlnvYgjPq1"
+    src="{% static 'js/promgen.js' %}?v=6"
+    integrity="{% sri_integrity_static 'js/promgen.js' %}"
     crossorigin="anonymous"
   ></script>
+  <script
+    src="{% static 'js/mixins.vue.js' %}"
+    integrity="{% sri_integrity_static 'js/mixins.vue.js' %}"
+    crossorigin="anonymous"
+  ></script>
+  <script
+    src="{% static 'js/promgen.vue.js' %}?v=7"
+    integrity="{% sri_integrity_static 'js/promgen.vue.js' %}"
+    crossorigin="anonymous"
+  ></script>
+  {% sri_static "js/rapidoc-9.3.8/rapidoc.min.js" %}
   {% block javascript %}{% endblock %}
 
   <datalist style="display:none" id="common.labels">

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "django-environ",
     "django-filter",
     "django-guardian",
+    "django-sri",
     "djangorestframework",
     "drf-spectacular",
     "kombu",


### PR DESCRIPTION
We have integrated Django SRI into Promgen and replaced the "static" template tag with "sri_static" to serve all static files with Subresource Integrity in the Production environment.