### PR TITLE
Add new APIs for integrating with Group

### DIFF
--- a/promgen/filters.py
+++ b/promgen/filters.py
@@ -234,3 +234,12 @@ class ProbeFilter(django_filters.rest_framework.FilterSet):
         lookup_expr="contains",
         help_text="Filter by probe module containing a specific substring. Example: probe=http_2xx",
     )
+
+
+class GroupFilter(django_filters.rest_framework.FilterSet):
+    name = django_filters.CharFilter(
+        field_name="name",
+        lookup_expr="contains",
+        help_text="Filter by group name containing a specific substring. "
+        "Example: name=Example Group",
+    )

--- a/promgen/fixtures/testcases.yaml
+++ b/promgen/fixtures/testcases.yaml
@@ -187,3 +187,11 @@
     duration: 1m
     enabled: true
     description: "Site Rule Description"
+- model: auth.group
+  pk: 1
+  fields:
+    name: "Test Group"
+- model: auth.group
+  pk: 2
+  fields:
+    name: "Other Group"

--- a/promgen/rest_v2.py
+++ b/promgen/rest_v2.py
@@ -13,6 +13,8 @@ from drf_spectacular.utils import (
     extend_schema_view,
 )
 from drf_spectacular.views import SpectacularAPIView
+from guardian.models import GroupObjectPermission
+from guardian.shortcuts import assign_perm, get_perms, remove_perm
 from rest_framework import mixins, pagination, routers, viewsets
 from rest_framework.authtoken.models import Token
 from rest_framework.decorators import action
@@ -22,6 +24,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from promgen import discovery, filters, models, permissions, serializers, signals, validators
+from promgen.templatetags import promgen as shortcuts
 
 
 class SpectacularRapiDocView(APIView):
@@ -541,3 +544,176 @@ class ProbeViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
     lookup_value_regex = "[^/]+"
     pagination_class = PromgenPagination
     permission_classes = [permissions.ReadOnlyForAuthenticatedUserOrIsSuperuser]
+
+
+@extend_schema_view(
+    list=extend_schema(summary="List Groups", description="Retrieve a list of all groups."),
+    retrieve=extend_schema(
+        summary="Retrieve Group",
+        description="Retrieve detailed information about a specific group.",
+    ),
+    create=extend_schema(summary="Create Group", description="Create a new group."),
+    update=extend_schema(summary="Update Group", description="Update an existing group."),
+    partial_update=extend_schema(
+        summary="Partially Update Group", description="Partially update an existing group."
+    ),
+    destroy=extend_schema(summary="Delete Group", description="Delete an existing group."),
+)
+@extend_schema(tags=["Group"])
+class GroupViewSet(viewsets.ModelViewSet):
+    queryset = models.Group.objects.all()
+    filterset_class = filters.GroupFilter
+    serializer_class = serializers.GroupRetrieveSerializer
+    lookup_value_regex = "[^/]+"
+    lookup_field = "id"
+    pagination_class = PromgenPagination
+    permission_classes = [permissions.PromgenGuardianRestPermission]
+
+    def get_queryset(self):
+        if self.request.user.is_superuser or self.action != "list":
+            return self.queryset
+        return permissions.get_accessible_groups_for_user(self.request.user)
+
+    @extend_schema(
+        summary="List Members",
+        description="Retrieve a list of all members in the specific group.",
+        responses=serializers.UserWithPermRetrieveSerializer(many=True),
+    )
+    @action(detail=True, methods=["get"], url_path="members")
+    def members(self, request, id):
+        group = self.get_object()
+
+        users_with_perm = shortcuts.get_users_roles(group)
+        members = []
+        for user, perm in users_with_perm:
+            members.append(
+                {
+                    "id": user.id,
+                    "username": user.username,
+                    "email": user.email,
+                    "role": perm[0].upper(),
+                }
+            )
+
+        page = self.paginate_queryset(members)
+        return self.get_paginated_response(
+            serializers.UserWithPermRetrieveSerializer(page, many=True).data
+        )
+
+    @extend_schema(
+        summary="Add Members",
+        description="Add list of members to the group.",
+        request=serializers.AddMemberGroupSerializer,
+        responses={204: None},
+    )
+    @members.mapping.post
+    def add_members(self, request, id):
+        group = self.get_object()
+        serializer = serializers.AddMemberGroupSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        already_members = User.objects.filter(
+            Q(id__in=serializer.validated_data["user_ids"])
+            & Q(id__in=group.user_set.values_list("id", flat=True))
+        )
+        new_members = User.objects.filter(id__in=serializer.validated_data["user_ids"]).exclude(
+            id__in=group.user_set.values_list("id", flat=True)
+        )
+
+        if already_members.exists():
+            raise ValidationError(
+                {
+                    "detail": "Users are already members of Group {group}: {users}".format(
+                        group=group.name,
+                        users=[user.username for user in already_members],
+                    )
+                }
+            )
+
+        if new_members.exists():
+            content_type = ContentType.objects.get_for_model(group)
+            permission = content_type.model + "_" + serializer.validated_data["group_role"].lower()
+            for user in new_members:
+                group.user_set.add(user)
+                assign_perm(permission, user, group)
+
+        return Response(status=HTTPStatus.NO_CONTENT)
+
+    @extend_schema(exclude=True)
+    @action(
+        detail=True,
+        methods=["get"],
+        url_path=r"members/(?P<user_id>\d+)",
+        pagination_class=None,
+        filterset_class=None,
+    )
+    def member(self, request, id, user_id):
+        raise MethodNotAllowed(request.method)
+
+    @extend_schema(
+        summary="Update Member",
+        description="Change role of a member in the group.",
+        request=serializers.UpdateMemberGroupSerializer,
+        responses={204: None},
+    )
+    @member.mapping.put
+    def update_member(self, request, id, user_id):
+        group = self.get_object()
+        user = User.objects.get(id=user_id)
+        serializer = serializers.UpdateMemberGroupSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        if group.user_set.filter(pk=user.pk).exists():
+            content_type = ContentType.objects.get_for_model(group)
+            permission = content_type.model + "_" + serializer.validated_data["group_role"].lower()
+            assign_perm(permission, user, group)
+        else:
+            raise ValidationError({"detail": f"User {user.id} is not a member of the group"})
+
+        return Response(status=HTTPStatus.NO_CONTENT)
+
+    @extend_schema(
+        summary="Remove Member",
+        description="Remove a member from the group.",
+        responses={204: None},
+    )
+    @member.mapping.delete
+    def remove_member(self, request, id, user_id):
+        group = self.get_object()
+        user = User.objects.get(id=user_id)
+
+        if group.user_set.filter(pk=user.pk).exists():
+            permissions = get_perms(user, group)
+            for perm in permissions:
+                remove_perm(perm, user, group)
+            group.user_set.remove(user)
+        else:
+            raise ValidationError({"detail": f"User {user.id} is not a member of the group."})
+
+        return Response(status=HTTPStatus.NO_CONTENT)
+
+    @extend_schema(
+        summary="List Assigned Resources",
+        description="Retrieve a list of all resources assigned with the specific group.",
+        responses=serializers.GroupAssignedResourceSerializer(many=True),
+    )
+    @action(detail=True, methods=["get"], url_path="resources")
+    def resources(self, request, id):
+        group = self.get_object()
+
+        resources = GroupObjectPermission.objects.filter(group=group)
+        assigned_resources = []
+        for resource in resources:
+            assigned_resources.append(
+                {
+                    "content_type": resource.content_type.model,
+                    "object_id": resource.content_object.id,
+                    "name": resource.content_object.name,
+                    "role": resource.permission.codename.split("_")[1].upper(),
+                }
+            )
+
+        page = self.paginate_queryset(assigned_resources)
+        return self.get_paginated_response(
+            serializers.GroupAssignedResourceSerializer(page, many=True).data
+        )

--- a/promgen/serializers.py
+++ b/promgen/serializers.py
@@ -315,3 +315,35 @@ class ProbeSerializer(serializers.ModelSerializer):
     class Meta:
         model = models.Probe
         fields = "__all__"
+
+
+class GroupRetrieveSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = models.Group
+        fields = ("id", "name")
+
+
+class UserWithPermRetrieveSerializer(serializers.Serializer):
+    id = serializers.IntegerField()
+    username = serializers.CharField()
+    email = serializers.EmailField()
+    role = serializers.CharField()
+
+
+class GroupAssignedResourceSerializer(serializers.Serializer):
+    content_type = serializers.CharField()
+    object_id = serializers.IntegerField()
+    name = serializers.CharField()
+    role = serializers.CharField()
+
+
+class AddMemberGroupSerializer(serializers.Serializer):
+    user_ids = serializers.ListField(
+        child=serializers.IntegerField(min_value=1),
+        allow_empty=False,
+    )
+    group_role = serializers.ChoiceField(choices=["ADMIN", "MEMBER"])
+
+
+class UpdateMemberGroupSerializer(serializers.Serializer):
+    group_role = serializers.ChoiceField(choices=["ADMIN", "MEMBER"])

--- a/promgen/tests/cases/test_rest_group.csv
+++ b/promgen/tests/cases/test_rest_group.csv
@@ -1,0 +1,41 @@
+case,user,permissions,method,viewname,kwargs,payload,expected_status,expected_response
+An unauthenticated user cannot list groups.,,,GET,api-v2:group-list,,,401,
+An unauthenticated user cannot create a group.,,,POST,api-v2:group-list,,"{""name"": ""new-group""}",401,
+An unauthenticated user cannot view group detail.,,,GET,api-v2:group-detail,"{""id"": 1}",,401,
+An unauthenticated user cannot update a group.,,,PUT,api-v2:group-detail,"{""id"": 1}","{""name"": ""Update""}",401,
+An unauthenticated user cannot partially update a group.,,,PATCH,api-v2:group-detail,"{""id"": 1}","{""name"": ""Update""}",401,
+An unauthenticated user cannot delete a group.,,,DELETE,api-v2:group-detail,"{""id"": 1}",,401,
+An unauthenticated user cannot list members of group.,,,GET,api-v2:group-members,"{""id"": 1}",,401,
+An unauthenticated user cannot add members to group.,,,POST,api-v2:group-members,"{""id"": 2}","{""user_ids"": [1], ""group_role"": ""MEMBER"" }",401,
+An unauthenticated user cannot update member of group.,,,PUT,api-v2:group-member,"{""id"": 2, ""user_id"": 1}","{""group_role"": ""ADMIN""}",401,
+An unauthenticated user cannot remove member from group.,,,DELETE,api-v2:group-member,"{""id"": 1, ""user_id"": 1}",,401,
+An unauthenticated user cannot list assigned resources of group.,,,GET,api-v2:group-resources,"{""id"": 1}",,401,
+An authenticated user without permissions see no groups.,demo,,GET,api-v2:group-list,,,200,"[]"
+An authenticated user without permissions can create a group.,demo,,POST,api-v2:group-list,,{"name": "new-group"},201,
+An authenticated user without permissions cannot view group detail.,demo,,GET,api-v2:group-detail,"{""id"": 1}",,403,
+An authenticated user without permissions cannot update a group.,demo,,PUT,api-v2:group-detail,"{""id"": 1}",,403,
+An authenticated user without permissions cannot partially update a group.,demo,,PATCH,api-v2:group-detail,"{""id"": 1}",,403,
+An authenticated user without permissions cannot delete a group.,demo,,DELETE,api-v2:group-detail,"{""id"": 1}",,403,
+An authenticated user without permissions cannot list members of group.,demo,,GET,api-v2:group-members,"{""id"": 1}",,403,
+An authenticated user without permissions cannot add members to group.,demo,,POST,api-v2:group-members,"{""id"": 2}","{""user_ids"": [1], ""group_role"": ""MEMBER"" }",403,
+An authenticated user without permissions cannot update member of group.,demo,,PUT,api-v2:group-member,"{""id"": 1, ""user_id"": 1}","{""group_role"": ""ADMIN""}",403,
+An authenticated user without permissions cannot remove member from group.,demo,,DELETE,api-v2:group-member,"{""id"": 1, ""user_id"": 1}",,403,
+An authenticated user without permissions cannot list assigned resources of group.,demo,,GET,api-v2:group-resources,"{""id"": 1}",,403,
+A member can list groups.,demo,"[{""codename"":""group_member"",""model"":""promgen.group"",""obj_pk"":1},{""codename"":""group_member"",""model"":""promgen.group"",""obj_pk"":2}]",GET,api-v2:group-list,,,200,"{""example"":""rest.group.list.json""}"
+A member can get paginated group results.,demo,"[{""codename"":""group_member"",""model"":""promgen.group"",""obj_pk"":1},{""codename"":""group_member"",""model"":""promgen.group"",""obj_pk"":2}]",GET,api-v2:group-list,,"{""page_number"": 1, ""page_size"": 1}",200,"{""results_length"":1}"
+A member can filter groups by name.,demo,"[{""codename"":""group_member"",""model"":""promgen.group"",""obj_pk"":1},{""codename"":""group_member"",""model"":""promgen.group"",""obj_pk"":2}]",GET,api-v2:group-list,,"{""name"": ""Test Group""}",200,"{""results_length"": 1}"
+A member can view group detail.,demo,"[{""codename"":""group_member"",""model"":""promgen.group"",""obj_pk"":1}]",GET,api-v2:group-detail,"{""id"": 1}",,200,"{""example"":""rest.group.detail.json""}"
+A member can list members of group.,demo,"[{""codename"":""group_member"",""model"":""promgen.group"",""obj_pk"":1}]",GET,api-v2:group-members,"{""id"": 1}",,200,"{""example"":""rest.group.detail.members.json""}"
+A member can list assigned resources of group.,demo,"[{""codename"":""group_member"",""model"":""promgen.group"",""obj_pk"":1}]",GET,api-v2:group-resources,"{""id"": 1}",,200,"{""example"":""rest.group.detail.resources.json""}"
+A member cannot update a group.,demo,"[{""codename"":""group_member"",""model"":""promgen.group"",""obj_pk"":1}]",PUT,api-v2:group-detail,"{""id"": 1}","{""name"": ""Update""}",403,
+A member cannot partially update a group.,demo,"[{""codename"":""group_member"",""model"":""promgen.group"",""obj_pk"":1}]",PATCH,api-v2:group-detail,"{""id"": 1}","{""name"": ""Update""}",403,
+A member cannot delete a group.,demo,"[{""codename"":""group_member"",""model"":""promgen.group"",""obj_pk"":1}]",DELETE,api-v2:group-detail,"{""id"": 1}",,403,
+A member cannot add members to group.,demo,"[{""codename"":""group_member"",""model"":""promgen.group"",""obj_pk"":2}]",POST,api-v2:group-members,"{""id"": 2}","{""user_ids"": [1], ""group_role"": ""MEMBER"" }",403,
+A member cannot update member of group.,demo,"[{""codename"":""group_member"",""model"":""promgen.group"",""obj_pk"":1}]",PUT,api-v2:group-member,"{""id"": 1, ""user_id"": 1}","{""group_role"": ""ADMIN""}",403,
+A member cannot remove member from group.,demo,"[{""codename"":""group_member"",""model"":""promgen.group"",""obj_pk"":1}]",DELETE,api-v2:group-member,"{""id"": 1, ""user_id"": 1}",,403,
+A group admin can update a group.,demo,"[{""codename"":""group_admin"",""model"":""promgen.group"",""obj_pk"":1}]",PUT,api-v2:group-detail,"{""id"": 1}","{""name"": ""Update""}",200,
+A group admin can partially update a group.,demo,"[{""codename"":""group_admin"",""model"":""promgen.group"",""obj_pk"":1}]",PATCH,api-v2:group-detail,"{""id"": 1}","{""name"": ""Update""}",200,
+A group admin can add members to group.,demo,"[{""codename"":""group_admin"",""model"":""promgen.group"",""obj_pk"":2}]",POST,api-v2:group-members,"{""id"": 2}","{""user_ids"": [1], ""group_role"": ""MEMBER"" }",204,
+A group admin can update member of group.,demo,"[{""codename"":""group_admin"",""model"":""promgen.group"",""obj_pk"":1}]",PUT,api-v2:group-member,"{""id"": 1, ""user_id"": 1}","{""group_role"": ""ADMIN""}",204,
+A group admin can remove member from group.,demo,"[{""codename"":""group_admin"",""model"":""promgen.group"",""obj_pk"":1}]",DELETE,api-v2:group-member,"{""id"": 1, ""user_id"": 1}",,204,
+A group admin can delete a group.,demo,"[{""codename"":""group_admin"",""model"":""promgen.group"",""obj_pk"":1}]",DELETE,api-v2:group-detail,"{""id"": 1}",,204,

--- a/promgen/tests/examples/rest.group.detail.json
+++ b/promgen/tests/examples/rest.group.detail.json
@@ -1,0 +1,4 @@
+{
+  "id": 1,
+  "name": "Test Group"
+}

--- a/promgen/tests/examples/rest.group.detail.members.json
+++ b/promgen/tests/examples/rest.group.detail.members.json
@@ -1,0 +1,19 @@
+{
+  "count": 2,
+  "next": null,
+  "previous": null,
+  "results": [
+    {
+      "id": 1,
+      "username": "admin",
+      "email": "admin@example.com",
+      "role": "ADMIN"
+    },
+    {
+      "id": 2,
+      "username": "demo",
+      "email": "demo@example.com",
+      "role": "MEMBER"
+    }
+  ]
+}

--- a/promgen/tests/examples/rest.group.detail.resources.json
+++ b/promgen/tests/examples/rest.group.detail.resources.json
@@ -1,0 +1,13 @@
+{
+  "count": 1,
+  "next": null,
+  "previous": null,
+  "results": [
+    {
+      "content_type": "service",
+      "object_id": 1,
+      "name": "test-service",
+      "role": "ADMIN"
+    }
+  ]
+}

--- a/promgen/tests/examples/rest.group.list.json
+++ b/promgen/tests/examples/rest.group.list.json
@@ -1,0 +1,15 @@
+{
+  "count": 2,
+  "next": null,
+  "previous": null,
+  "results": [
+    {
+      "id": 2,
+      "name": "Other Group"
+    },
+    {
+      "id": 1,
+      "name": "Test Group"
+    }
+  ]
+}

--- a/promgen/tests/test_rest.py
+++ b/promgen/tests/test_rest.py
@@ -44,6 +44,8 @@ class RestAPITest(tests.PromgenTest):
                     model = django_apps.get_model(app_label, model_name)
                     obj = model.objects.get(pk=obj_pk)
                     assign_perm(perm, user, obj)
+                    if isinstance(obj, models.Group):
+                        obj.user_set.add(user)
 
             url = reverse(viewname, kwargs=kwargs or None)
             request_kwargs = {}
@@ -96,6 +98,8 @@ class RestAPITest(tests.PromgenTest):
                     try:
                         obj = model.objects.get(pk=obj_pk)
                         remove_perm(perm, user, obj)
+                        if isinstance(obj, models.Group):
+                            obj.user_set.remove(user)
                     except model.DoesNotExist:
                         pass
 
@@ -266,3 +270,21 @@ class RestAPITest(tests.PromgenTest):
         cases = tests.Data("cases", "test_rest_url.csv").csv()
         for case in cases:
             self._run_rest_test(case)
+
+    @override_settings(PROMGEN=tests.SETTINGS)
+    def test_rest_group(self):
+        # Initialize test data
+        admin = User.objects.get(username="admin")
+        test_group = models.Group.objects.get(pk=1)
+        test_group.user_set.add(admin)
+        assign_perm("group_admin", admin, test_group)
+        test_service = models.Service.objects.get(pk=1)
+        assign_perm("service_admin", test_group, test_service)
+
+        cases = tests.Data("cases", "test_rest_group.csv").csv()
+        for case in cases:
+            self._run_rest_test(case)
+
+            # Delete newly created group to avoid affecting other tests
+            if case["case"] == "An authenticated user without permissions can create a group.":
+                models.Group.objects.get(name="new-group").delete()

--- a/promgen/tests/test_signals.py
+++ b/promgen/tests/test_signals.py
@@ -89,7 +89,7 @@ class SignalTest(tests.PromgenTest):
         service = models.Service.objects.get(pk=1)
         project = service.project_set.first()
         assign_perm("project_viewer", self.user, project)
-        group = models.Group.objects.create(name="Test Group")
+        group = models.Group.objects.get(pk=1)
         group.user_set.add(self.user)
 
         NotificationUser.create(obj=project, value=str(self.user.pk), owner=self.user)
@@ -133,7 +133,7 @@ class SignalTest(tests.PromgenTest):
     def test_unsubscribe_when_removing_permission(self, log_mock):
         service = models.Service.objects.get(pk=1)
         project = service.project_set.first()
-        group = models.Group.objects.create(name="Test Group")
+        group = models.Group.objects.get(pk=1)
         group.user_set.add(self.user)
 
         # 1. Check if removing user permission unsubscribes user
@@ -175,7 +175,7 @@ class SignalTest(tests.PromgenTest):
     @mock.patch("promgen.models.Audit.log")
     def test_unsubscribe_when_removing_user_from_group(self, log_mock):
         service = models.Service.objects.get(pk=1)
-        group = models.Group.objects.create(name="Test Group")
+        group = models.Group.objects.get(pk=1)
 
         group.user_set.add(self.user)
         assign_perm("service_viewer", group, service)

--- a/promgen/tests/test_web.py
+++ b/promgen/tests/test_web.py
@@ -169,7 +169,7 @@ class WebTests(PromgenTest):
         )
         assign_perm("service_viewer", user_to_merge_from, test_service)
 
-        group = models.Group.objects.create(name="Test Group")
+        group = models.Group.objects.get(pk=1)
         user_to_merge_from.groups.add(group)
         assign_perm("group_admin", user_to_merge_from, group)
         assign_perm("group_member", user_to_merge_into, group)

--- a/promgen/urls.py
+++ b/promgen/urls.py
@@ -38,6 +38,7 @@ v2_router.register("farms", rest_v2.FarmViewSet)
 v2_router.register("exporters", rest_v2.ExporterViewSet)
 v2_router.register("urls", rest_v2.URLViewSet)
 v2_router.register("probes", rest_v2.ProbeViewSet)
+v2_router.register("groups", rest_v2.GroupViewSet)
 
 urlpatterns = [
     path("admin/", admin.site.urls),


### PR DESCRIPTION
We have added several APIs to support users integrating with Promgen's Groups:
- List and filter Group.
- Retrieve detailed information about an existing Group.
- Update or partially update an existing Group.
- Delete an existing Group.
- List members of an existing Group.
- List assigned resources of an existing Group.
- Add members to an existing Group.
- Change role of a member in an existing Group.
- Remove a member from an existing Group.