### PR TITLE
Avoid sending Alert notifications to wrong targets

### DIFF
--- a/promgen/models.py
+++ b/promgen/models.py
@@ -577,6 +577,17 @@ class Alert(models.Model):
                 routable[label] = obj
                 data["commonAnnotations"][label] = resolve_domain(obj)
 
+        project = routable.get("project")
+        service = routable.get("service")
+        if project and service and project.service != service:
+            logger.warning(
+                "Project %s does not belong to Service %s, ignoring both",
+                routable["project"],
+                routable["service"],
+            )
+            routable.pop("project")
+            routable.pop("service")
+
         return routable, data
 
     @cached_property

--- a/promgen/tests/test_alert_rules.py
+++ b/promgen/tests/test_alert_rules.py
@@ -150,3 +150,26 @@ class RuleTest(tests.PromgenTest):
         rule.annotations["has a space"] = "value"
         with self.assertRaises(ValidationError):
             prometheus.check_rules([rule])
+
+    @override_settings(PROMGEN=tests.SETTINGS)
+    @override_settings(CELERY_TASK_ALWAYS_EAGER=True)
+    @override_settings(CELERY_TASK_EAGER_PROPAGATES=True)
+    @mock.patch("promgen.util.post")
+    def test_alert_routable(self, mock_post):
+        self.user = self.force_login(username="admin")
+        data = tests.Data("examples", "alertmanager.json").json()
+
+        self.fireAlert(data=data)
+        self.assertEqual(
+            mock_post.call_count, 1, "One alert should be sent because of correct routable."
+        )
+
+        mock_post.reset_mock()
+        data["commonLabels"]["service"] = "other-service"
+        self.fireAlert(data=data)
+        self.assertEqual(
+            mock_post.call_count,
+            0,
+            "No alert should be sent because of wrong routable "
+            "(project now doesn't match with service).",
+        )


### PR DESCRIPTION
When Promgen receives an Alert from Alertmanager, it sends notifications to corresponding services and projects based on the "service" and "project" labels of the Alert. However, these labels can sometimes be inaccurate as they are recorded entirely from the Prometheus side. In such cases, Promgen still sends notifications to unintended targets. To avoid this, we have checked the relationship between the service and project labels before creating the routable of the Alert.