### PR TITLE
Automatically set labels for Rule

### DIFF
--- a/promgen/models.py
+++ b/promgen/models.py
@@ -507,18 +507,20 @@ class Rule(models.Model):
                 f'{content_type.model}="{content_object.name}",{macro.EXCLUSION_MACRO}',
             )
 
-            # Add a label to our new rule by default, to help ensure notifications
-            # get routed to the notifier we expect
-            self.labels[content_type.model] = content_object.name
-
             self.save()
 
         return self
 
-    # Custom logic before saving Rule to control the value of the annotation "rule":
-    # Format: annotations["rule"] = {domain}/rule/{id}
+    # Custom logic before saving Rule to control the values of the annotations and labels:
     def save(self, *args, **kwargs):
         with transaction.atomic():
+            # If the rule is associated with a Service or Project, we set labels to the rule
+            if isinstance(self.content_object, Service):
+                self.labels["service"] = self.content_object.name
+            if isinstance(self.content_object, Project):
+                self.labels["project"] = self.content_object.name
+
+            # Always set the annotations["rule"] to be {domain}/rule/{id}
             if self.pk:
                 # When updating rule, we already have the primary key.
                 # Just set annotations["rule"] before saving to database.

--- a/promgen/tests/test_models.py
+++ b/promgen/tests/test_models.py
@@ -69,3 +69,51 @@ class ModelTest(PromgenTest):
         new_rule = rule.copy_to(content_type="service", object_id=2)
         self.assertEqual(resolve_domain("rule-detail", rule.pk), rule.annotations["rule"])
         self.assertEqual(resolve_domain("rule-detail", new_rule.pk), new_rule.annotations["rule"])
+
+    @mock.patch("django.dispatch.dispatcher.Signal.send")
+    def test_rule_label(self, mock_post):
+        site = models.Site.objects.get(pk=1)
+        service = models.Service.objects.get(pk=1)
+        project = models.Project.objects.get(pk=1)
+
+        # Check if Site Rule has no "service" and "project" labels when creating a new rule
+        site_rule = models.Rule(
+            name="New Site Rule",
+            content_object=site,
+            clause="up==1",
+            duration="1s",
+        )
+        site_rule.save()
+        self.assertIsNone(site_rule.labels.get("service", None))
+        self.assertIsNone(site_rule.labels.get("project", None))
+
+        # Check if Service Rule has "service" label when creating a new rule
+        service_rule = models.Rule(
+            name="New Service Rule",
+            content_object=service,
+            clause="up==1",
+            duration="1s",
+        )
+        service_rule.save()
+        self.assertEqual(service_rule.labels.get("service", None), service.name)
+        self.assertIsNone(service_rule.labels.get("project", None))
+
+        # Check if Project Rule has "project" label when creating a new rule
+        project_rule = models.Rule(
+            name="New Project Rule",
+            content_object=project,
+            clause="up==1",
+            duration="1s",
+        )
+        project_rule.save()
+        self.assertIsNone(project_rule.labels.get("service", None))
+        self.assertEqual(project_rule.labels.get("project", None), project.name)
+
+        # Check if "service" label of Service Rule cannot be modified
+        service_rule.labels["service"] = "other-service"
+        service_rule.save()
+        self.assertEqual(service_rule.labels.get("service", None), service.name)
+
+        # Check if Service Rule has "service" label when overwriting from a Site rule
+        overwritten_rule = site_rule.copy_to(content_type="service", object_id=service.id)
+        self.assertEqual(overwritten_rule.labels.get("service", None), service.name)

--- a/promgen/views.py
+++ b/promgen/views.py
@@ -1215,7 +1215,6 @@ class AlertRuleRegister(PromgenGuardianPermissionMixin, mixins.RuleFormMixin, Fo
         return context
 
     def form_valid(self, form):
-        form.instance.labels[form.instance.content_type.model] = form.instance.content_object.name
         form.instance.save()
         return HttpResponseRedirect(form.instance.get_absolute_url())
 


### PR DESCRIPTION
We have changed to set the value of the Rule's "service" and "project" labels to always match the name of the Service and Project at the models layer instead of views layer. This ensures that user will not be able to modify these labels and Alerts from Alertmanager are correctly routed to the Service or Project that the Rule belongs to.