### PR TITLE
Add new APIs for integrating with Shard

### DIFF
--- a/promgen/filters.py
+++ b/promgen/filters.py
@@ -8,7 +8,12 @@ from promgen import models
 
 
 class ShardFilter(django_filters.rest_framework.FilterSet):
-    name = django_filters.CharFilter(field_name="name", lookup_expr="contains")
+    name = django_filters.CharFilter(
+        field_name="name",
+        lookup_expr="contains",
+        help_text="Filter by shard name containing a specific substring. "
+        "Example: name=Example Shard",
+    )
 
 
 class ServiceFilter(django_filters.rest_framework.FilterSet):

--- a/promgen/fixtures/testcases.yaml
+++ b/promgen/fixtures/testcases.yaml
@@ -41,6 +41,13 @@
     url: http://prometheus.example.com
     proxy: true
     enabled: true
+- model: promgen.shard
+  pk: 2
+  fields:
+    name: other-shard
+    url: http://prometheus-002.example.com
+    proxy: false
+    enabled: false
 - model: promgen.service
   pk: 1
   fields:

--- a/promgen/models.py
+++ b/promgen/models.py
@@ -17,7 +17,7 @@ from django.utils.functional import cached_property
 from django.utils.text import slugify
 
 import promgen.templatetags.promgen as macro
-from promgen import plugins, tests, validators
+from promgen import plugins, tests, util, validators
 from promgen.shortcuts import resolve_domain
 
 logger = logging.getLogger(__name__)
@@ -224,6 +224,28 @@ class Shard(models.Model):
         if self.enabled:
             return self.name
         return self.name + " (disabled)"
+
+    @property
+    def samples_count(self):
+        return self._query_count("sum(scrape_samples_scraped)", "sample count")
+
+    @property
+    def targets_count(self):
+        return self._query_count("count(up)", "target count")
+
+    def _query_count(self, query, metric_name):
+        try:
+            headers = {"Authorization": self.authorization} if self.authorization else {}
+            response = util.get(
+                f"{self.url}/api/v1/query", params={"query": query}, headers=headers
+            )
+            response.raise_for_status()
+            data = response.json()
+            value = data["data"]["result"][0]["value"][1]
+            return int(value)
+        except Exception as e:
+            logger.warning("Error fetching %s for shard %s: %s", metric_name, self.name, e)
+            return 0
 
 
 class Service(models.Model):

--- a/promgen/rest_v2.py
+++ b/promgen/rest_v2.py
@@ -1381,3 +1381,16 @@ class UserViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
             serializers.NotifierSerializer(notifier).data,
             status=HTTPStatus.CREATED,
         )
+
+
+@extend_schema_view(
+    list=extend_schema(summary="List Shards", description="Retrieve a list of all shards."),
+)
+@extend_schema(tags=["Shard"])
+class ShardViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
+    queryset = models.Shard.objects.all()
+    filterset_class = filters.ShardFilter
+    serializer_class = serializers.ShardRetrieveDetailSerializer
+    lookup_value_regex = "[^/]+"
+    lookup_field = "id"
+    pagination_class = PromgenPagination

--- a/promgen/rest_v2.py
+++ b/promgen/rest_v2.py
@@ -1385,9 +1385,13 @@ class UserViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
 
 @extend_schema_view(
     list=extend_schema(summary="List Shards", description="Retrieve a list of all shards."),
+    retrieve=extend_schema(
+        summary="Retrieve Shard",
+        description="Retrieve detailed information about a specific shard.",
+    ),
 )
 @extend_schema(tags=["Shard"])
-class ShardViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
+class ShardViewSet(mixins.RetrieveModelMixin, mixins.ListModelMixin, viewsets.GenericViewSet):
     queryset = models.Shard.objects.all()
     filterset_class = filters.ShardFilter
     serializer_class = serializers.ShardRetrieveDetailSerializer

--- a/promgen/serializers.py
+++ b/promgen/serializers.py
@@ -504,3 +504,12 @@ class UserRetrieveDetailSerializer(serializers.ModelSerializer):
             "is_superuser",
             "date_joined",
         )
+
+
+class ShardRetrieveDetailSerializer(serializers.ModelSerializer):
+    samples_count = serializers.IntegerField(read_only=True, help_text="Number of samples.")
+    targets_count = serializers.IntegerField(read_only=True, help_text="Number of targets.")
+
+    class Meta:
+        model = models.Shard
+        exclude = ("authorization",)

--- a/promgen/tests/cases/test_rest_shard.csv
+++ b/promgen/tests/cases/test_rest_shard.csv
@@ -1,5 +1,7 @@
 case,user,permissions,method,viewname,kwargs,payload,expected_status,expected_response
 An unauthenticated user cannot view the shard list.,,,GET,api-v2:shard-list,,,401,
+An unauthenticated user cannot view the shard detail.,,,GET,api-v2:shard-detail,"{""id"": 1}",,401,
 An authenticated user can view the shard list.,demo,,GET,api-v2:shard-list,,,200,"{""example"": ""rest.shard.list.json""}"
 An authenticated user can view the paginated shard list.,demo,,GET,api-v2:shard-list,,"{""page_number"": 1, ""page_size"": 1}",200,"{""results_length"": 1}"
 An authenticated user can filter the shard list by name.,demo,,GET,api-v2:shard-list,,"{""name"": ""test""}",200,"{""results_length"": 1}"
+An authenticated user can view the shard detail.,demo,,GET,api-v2:shard-detail,"{""id"": 1}",,200,"{""example"": ""rest.shard.detail.json""}"

--- a/promgen/tests/cases/test_rest_shard.csv
+++ b/promgen/tests/cases/test_rest_shard.csv
@@ -1,0 +1,5 @@
+case,user,permissions,method,viewname,kwargs,payload,expected_status,expected_response
+An unauthenticated user cannot view the shard list.,,,GET,api-v2:shard-list,,,401,
+An authenticated user can view the shard list.,demo,,GET,api-v2:shard-list,,,200,"{""example"": ""rest.shard.list.json""}"
+An authenticated user can view the paginated shard list.,demo,,GET,api-v2:shard-list,,"{""page_number"": 1, ""page_size"": 1}",200,"{""results_length"": 1}"
+An authenticated user can filter the shard list by name.,demo,,GET,api-v2:shard-list,,"{""name"": ""test""}",200,"{""results_length"": 1}"

--- a/promgen/tests/examples/rest.shard.detail.json
+++ b/promgen/tests/examples/rest.shard.detail.json
@@ -1,0 +1,11 @@
+{
+  "enabled": true,
+  "id": 1,
+  "name": "test-shard",
+  "proxy": true,
+  "samples": 5000000,
+  "targets": 10000,
+  "url": "http://prometheus.example.com",
+  "samples_count": 0,
+  "targets_count": 0
+}

--- a/promgen/tests/examples/rest.shard.list.json
+++ b/promgen/tests/examples/rest.shard.list.json
@@ -1,0 +1,29 @@
+{
+  "count": 2,
+  "next": null,
+  "previous": null,
+  "results": [
+    {
+      "enabled": false,
+      "id": 2,
+      "name": "other-shard",
+      "proxy": false,
+      "samples": 5000000,
+      "targets": 10000,
+      "url": "http://prometheus-002.example.com",
+      "samples_count": 0,
+      "targets_count": 0
+    },
+    {
+      "enabled": true,
+      "id": 1,
+      "name": "test-shard",
+      "proxy": true,
+      "samples": 5000000,
+      "targets": 10000,
+      "url": "http://prometheus.example.com",
+      "samples_count": 0,
+      "targets_count": 0
+    }
+  ]
+}

--- a/promgen/tests/test_rest.py
+++ b/promgen/tests/test_rest.py
@@ -558,3 +558,9 @@ class RestAPITest(tests.PromgenTest):
         cases = tests.Data("cases", "test_rest_user.csv").csv()
         for case in cases:
             self._run_rest_test(case)
+
+    @override_settings(PROMGEN=tests.SETTINGS)
+    def test_rest_shard(self):
+        cases = tests.Data("cases", "test_rest_shard.csv").csv()
+        for case in cases:
+            self._run_rest_test(case)

--- a/promgen/urls.py
+++ b/promgen/urls.py
@@ -42,6 +42,7 @@ v2_router.register("groups", rest_v2.GroupViewSet)
 v2_router.register("projects", rest_v2.ProjectViewSet)
 v2_router.register("services", rest_v2.ServiceViewSet)
 v2_router.register("users", rest_v2.UserViewSet)
+v2_router.register("shards", rest_v2.ShardViewSet)
 
 urlpatterns = [
     path("admin/", admin.site.urls),


### PR DESCRIPTION
We have added several APIs to support users integrating with Promgen's Shard:
- List and filter Shard.
- Retrieve detailed information about an existing Shard.