### PR TITLE
Add new APIs for integrating with Site

### DIFF
--- a/promgen/rest_v2.py
+++ b/promgen/rest_v2.py
@@ -313,7 +313,9 @@ class RuleMixin:
         serializer.is_valid(raise_exception=True)
 
         attributes = {
-            "content_type_id": ContentType.objects.get_for_model(object).id,
+            "content_type_id": ContentType.objects.get_for_model(
+                object, for_concrete_model=False
+            ).id,
             "object_id": object.id,
         }
 
@@ -1401,7 +1403,7 @@ class ShardViewSet(mixins.RetrieveModelMixin, mixins.ListModelMixin, viewsets.Ge
 
 
 @extend_schema(tags=["Site"])
-class SiteViewSet(viewsets.GenericViewSet):
+class SiteViewSet(RuleMixin, viewsets.GenericViewSet):
     queryset = models.Site.objects.all()
     lookup_value_regex = "[^/]+"
     lookup_field = "id"

--- a/promgen/rest_v2.py
+++ b/promgen/rest_v2.py
@@ -1398,3 +1398,22 @@ class ShardViewSet(mixins.RetrieveModelMixin, mixins.ListModelMixin, viewsets.Ge
     lookup_value_regex = "[^/]+"
     lookup_field = "id"
     pagination_class = PromgenPagination
+
+
+@extend_schema(tags=["Site"])
+class SiteViewSet(viewsets.GenericViewSet):
+    queryset = models.Site.objects.all()
+    lookup_value_regex = "[^/]+"
+    lookup_field = "id"
+    pagination_class = PromgenPagination
+    permission_classes = [permissions.PromgenGuardianRestPermission]
+
+    @extend_schema(
+        summary="Get Current Site",
+        description="Retrieve the current site's information.",
+        responses=serializers.SiteRetrieveSerializer,
+    )
+    @action(detail=False, methods=["get"], url_path="info")
+    def get_current_site(self, request):
+        current_site = models.Site.objects.get_current()
+        return Response(serializers.SiteRetrieveSerializer(current_site).data)

--- a/promgen/serializers.py
+++ b/promgen/serializers.py
@@ -513,3 +513,9 @@ class ShardRetrieveDetailSerializer(serializers.ModelSerializer):
     class Meta:
         model = models.Shard
         exclude = ("authorization",)
+
+
+class SiteRetrieveSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = models.Site
+        fields = "__all__"

--- a/promgen/tests/cases/test_rest_site.csv
+++ b/promgen/tests/cases/test_rest_site.csv
@@ -1,0 +1,3 @@
+case,user,permissions,method,viewname,kwargs,payload,expected_status,expected_response
+An unauthenticated user cannot retrieve the current Site Rule's information.,,,GET,api-v2:site-get-current-site,,,401,
+An authenticated user can retrieve the current Site Rule's information.,demo,,GET,api-v2:site-get-current-site,,,200,"{""example"": ""rest.site.detail.json""}"

--- a/promgen/tests/cases/test_rest_site.csv
+++ b/promgen/tests/cases/test_rest_site.csv
@@ -1,3 +1,6 @@
 case,user,permissions,method,viewname,kwargs,payload,expected_status,expected_response
 An unauthenticated user cannot retrieve the current Site Rule's information.,,,GET,api-v2:site-get-current-site,,,401,
+An unauthenticated user cannot register a Site Rule.,,,POST,api-v2:site-rules,"{""id"": 1}",,401,
 An authenticated user can retrieve the current Site Rule's information.,demo,,GET,api-v2:site-get-current-site,,,200,"{""example"": ""rest.site.detail.json""}"
+An authenticated user cannot register a Site Rule.,demo,,POST,api-v2:site-rules,"{""id"": 1}",,403,
+A Site Admin can register a Site Rule.,admin,,POST,api-v2:site-rules,"{""id"": 1}","{""annotations"": {""summary"": ""Test Rule Summary""}, ""clause"": ""up == 1"", ""description"": ""Test Rule Description"", ""duration"": ""5m"", ""enabled"": false, ""labels"": {""severity"": ""critical""}, ""name"": ""TestRuleCreated""}",201,

--- a/promgen/tests/examples/rest.site.detail.json
+++ b/promgen/tests/examples/rest.site.detail.json
@@ -1,0 +1,5 @@
+{
+  "id": 1,
+  "domain": "promgen.example.com",
+  "name": "CI Test"
+}

--- a/promgen/tests/test_rest.py
+++ b/promgen/tests/test_rest.py
@@ -564,3 +564,9 @@ class RestAPITest(tests.PromgenTest):
         cases = tests.Data("cases", "test_rest_shard.csv").csv()
         for case in cases:
             self._run_rest_test(case)
+
+    @override_settings(PROMGEN=tests.SETTINGS)
+    def test_rest_site(self):
+        cases = tests.Data("cases", "test_rest_site.csv").csv()
+        for case in cases:
+            self._run_rest_test(case)

--- a/promgen/urls.py
+++ b/promgen/urls.py
@@ -43,6 +43,7 @@ v2_router.register("projects", rest_v2.ProjectViewSet)
 v2_router.register("services", rest_v2.ServiceViewSet)
 v2_router.register("users", rest_v2.UserViewSet)
 v2_router.register("shards", rest_v2.ShardViewSet)
+v2_router.register("sites", rest_v2.SiteViewSet)
 
 urlpatterns = [
     path("admin/", admin.site.urls),


### PR DESCRIPTION
We have added several APIs to support users integrating with Promgen's Site:
- Retrieve detailed information about the current Site.
- Register new Rule to the current Site.