### PR TITLE
Change the serializer class of Registering Rule API

### DIFF
--- a/promgen/rest_v2.py
+++ b/promgen/rest_v2.py
@@ -303,13 +303,13 @@ class RuleMixin:
     @extend_schema(
         summary="Register Rule",
         description="Register a new rule for the specified object.",
-        request=serializers.RuleRetrieveSimpleSerializer,
-        responses={201: serializers.RuleRetrieveSimpleSerializer},
+        request=serializers.RuleRetrieveDetailSerializer,
+        responses={201: serializers.RuleRetrieveDetailSerializer},
     )
     @rules.mapping.post
     def register_rule(self, request, id):
         object = self.get_object()
-        serializer = serializers.RuleRetrieveSimpleSerializer(data=request.data)
+        serializer = serializers.RuleRetrieveDetailSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
 
         attributes = {
@@ -324,7 +324,7 @@ class RuleMixin:
 
         rule, created = models.Rule.objects.get_or_create(**attributes)
         return Response(
-            serializers.RuleRetrieveSimpleSerializer(rule).data, status=HTTPStatus.CREATED
+            serializers.RuleRetrieveDetailSerializer(rule).data, status=HTTPStatus.CREATED
         )
 
 


### PR DESCRIPTION
We have changed to use RuleRetrieveDetailSerializer for the Registering new Rule API, instead of using RuleRetrieveSimpleSerializer class. There are two reasons for this change:
- RuleRetrieveDetailSerializer has the "parent" field as read_only_field. We should not allow user to set the parent Rule when registering a new Rule because it is only added when an existing Rule is overridden.
- RuleRetrieveDetailSerializer includes the fields "annotations," "description," and "labels." These fields are useful for users. Users should be able to set them when registering a new Rule.