### PR TITLE
Not allow registering Project to disabled Shard

### DIFF
--- a/promgen/forms.py
+++ b/promgen/forms.py
@@ -149,6 +149,19 @@ class ServiceUpdate(forms.ModelForm):
         exclude = []
 
 
+class ProjectRegister(forms.ModelForm):
+    class Meta:
+        model = models.Project
+        # service is determined by the pk in the project register url
+        exclude = ["service"]
+
+    def clean_shard(self):
+        shard = self.cleaned_data["shard"]
+        if not shard.enabled:
+            raise ValidationError("Shard is disabled.")
+        return shard
+
+
 class URLForm(forms.ModelForm):
     class Meta:
         model = models.URL

--- a/promgen/forms.py
+++ b/promgen/forms.py
@@ -162,6 +162,19 @@ class ProjectRegister(forms.ModelForm):
         return shard
 
 
+class ProjectUpdate(forms.ModelForm):
+    class Meta:
+        model = models.Project
+        exclude = []
+
+    def clean_shard(self):
+        shard = self.cleaned_data["shard"]
+        # If the shard is being changed, we need to make sure that the new shard is enabled.
+        if shard != self.instance.shard and not shard.enabled:
+            raise ValidationError("Shard is disabled.")
+        return shard
+
+
 class URLForm(forms.ModelForm):
     class Meta:
         model = models.URL

--- a/promgen/serializers.py
+++ b/promgen/serializers.py
@@ -494,6 +494,11 @@ class RegisterProjectToServiceSerializer(serializers.ModelSerializer):
         fields = "__all__"
         read_only_fields = ("service", "owner")
 
+    def validate_shard(self, shard):
+        if not shard.enabled:
+            raise serializers.ValidationError("Shard is disabled.")
+        return shard
+
 
 class UserRetrieveSimpleSerializer(serializers.ModelSerializer):
     class Meta:

--- a/promgen/serializers.py
+++ b/promgen/serializers.py
@@ -368,6 +368,12 @@ class ProjectSimpleSerializer(serializers.ModelSerializer):
         model = models.Project
         fields = "__all__"
 
+    def validate_shard(self, shard):
+        # If the shard is being changed, we need to make sure that the new shard is enabled.
+        if shard != self.instance.shard and not shard.enabled:
+            raise serializers.ValidationError("Shard is disabled.")
+        return shard
+
 
 class ShardRetrieveSerializer(serializers.ModelSerializer):
     class Meta:

--- a/promgen/views.py
+++ b/promgen/views.py
@@ -1047,7 +1047,7 @@ class ProjectUpdate(PromgenGuardianPermissionMixin, UpdateView):
     model = models.Project
     button_label = _("Project Update")
     template_name = "promgen/project_form.html"
-    fields = ["name", "description", "owner", "service", "shard"]
+    form_class = forms.ProjectUpdate
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)

--- a/promgen/views.py
+++ b/promgen/views.py
@@ -1012,7 +1012,7 @@ class ProjectRegister(PromgenGuardianPermissionMixin, CreateView):
     permission_required = ["service_admin", "service_editor"]
     button_label = _("Register Project")
     model = models.Project
-    fields = ["name", "description", "owner", "shard"]
+    form_class = forms.ProjectRegister
 
     def get_initial(self):
         initial = {}


### PR DESCRIPTION
Add multiple Shard validations to Promgen's forms and serializers to ensure that user cannot registering a Project to a disabled Shard whether when registering a new Project or updating an existing Project.