### PR TITLE
Specify field type for Rule serializer's labels and annotations

### DIFF
--- a/promgen/serializers.py
+++ b/promgen/serializers.py
@@ -251,6 +251,16 @@ class RuleRetrieveSimpleSerializer(serializers.ModelSerializer):
 class RuleRetrieveDetailSerializer(serializers.ModelSerializer):
     content_name = serializers.CharField(read_only=True, source="content_object.name")
     content_type = serializers.CharField(read_only=True, source="content_type.model")
+    annotations = serializers.DictField(
+        required=False,
+        child=serializers.CharField(),
+        help_text="Provide extra details for notifications",
+    )
+    labels = serializers.DictField(
+        required=False,
+        child=serializers.CharField(),
+        help_text="Control routing through AlertManager and Promgen",
+    )
 
     class Meta:
         model = models.Rule


### PR DESCRIPTION
We have specified the type for labels and annotations in the Rule serializer to be a dictionary of strings. This change provides more detailed descriptions for Rule APIs's requests and responses in the API schema, as well as improving generated examples of these APIs.

**AS-IS:**
<img width="668" height="310" alt="image" src="https://github.com/user-attachments/assets/70e5455c-0850-43fb-a587-b16357a3edf7" />
<img width="262" height="199" alt="image" src="https://github.com/user-attachments/assets/ef43aebb-cb1d-4093-914d-ab5778ca8a9f" />



**TO-BE:**
<img width="678" height="419" alt="image" src="https://github.com/user-attachments/assets/4147f6ac-23c1-45f2-83ee-1a91dc3144a1" />
<img width="272" height="269" alt="image" src="https://github.com/user-attachments/assets/07c7aef8-d48a-4fbb-b4fc-5efbbb89fa47" />
