### PR TITLE
Query Hosts exactly by hostname on the HostDetail page

### DIFF
--- a/promgen/views.py
+++ b/promgen/views.py
@@ -196,9 +196,7 @@ class HostDetail(LoginRequiredMixin, View):
         context = {}
         context["slug"] = self.kwargs["slug"]
 
-        hosts = models.Host.objects.filter(name__icontains=self.kwargs["slug"]).prefetch_related(
-            "farm"
-        )
+        hosts = models.Host.objects.filter(name=self.kwargs["slug"]).prefetch_related("farm")
 
         # If the user is not a superuser, we need to filter the hosts by the user's permissions
         if not self.request.user.is_superuser:


### PR DESCRIPTION
Currently, the HostDetail page does not display information based on a specific Host object. Instead, it queries a list of Hosts containing a given hostname. This is reasonable because we have changed it so that each Farm belongs to only one Project, which has led to the possibility of duplicate hostnames. However, using a "contains" query for the hostname field is unreasonable as it may return a list of unrelated information.

Therefore, we have changed the "contains" query to an "exact" query for the hostname field in this case to ensure the returned information truly corresponds to the given hostname.