### PR TITLE
[Chores] Change name of the Farm panel on the HostDetail page

### DIFF
--- a/promgen/templates/promgen/host_detail.html
+++ b/promgen/templates/promgen/host_detail.html
@@ -15,7 +15,7 @@
 </div>
 
 <div class="panel panel-primary">
-  <div class="panel-heading">Farm</div>
+  <div class="panel-heading">Farms</div>
   <table class="table">
     <tr>
       <th>Name</th>


### PR DESCRIPTION
Currently, the HostDetail page displays information related to a hostname instead of a specific Host object. However, different Host objects belonging to different Farms can contain the same hostname. In fact, this occurs more frequently because previously, we changed it so that each Farm on Promgen only belongs to one Project. As a result, a hostname can completely belong to multiple different Farms.

Therefore, we have renamed the Farm panel on the HostDetail page to the plural form "Farms" to more accurately reflect this information.