### PR TITLE
Support for Logging in API V2

### DIFF
--- a/promgen/middleware.py
+++ b/promgen/middleware.py
@@ -17,8 +17,10 @@ files, we need to handle some deduplication. This is handled by using the django
 caching system to set a key and then triggering the actual event from middleware
 """
 
+import json
 import logging
 import socket
+import uuid
 from datetime import datetime
 from threading import local
 
@@ -26,7 +28,7 @@ from django.contrib import messages
 from django.contrib.admindocs.views import simplify_regex
 from django.db.models import prefetch_related_objects
 
-from promgen import metrics, models
+from promgen import metrics, models, settings, util
 from promgen.signals import trigger_write_config, trigger_write_rules, trigger_write_urls
 
 logger = logging.getLogger(__name__)
@@ -77,9 +79,43 @@ class PromgenMonitoringMiddleware:
         self.get_response = get_response
 
     def __call__(self, request):
+        # Log all requests to our v2 API endpoints
+        if settings.V2_API_LOGGING_ENABLED and request.path.startswith("/rest/v2/"):
+            # Generate a trace ID for each request
+            request.trace_id = str(uuid.uuid4())
+            try:
+                truncated_body = (
+                    util.truncate_json_fields(json.loads(request.body))
+                    if request.body and request.headers["Content-Type"] == "application/json"
+                    else None
+                )
+                logger.info(
+                    f"[Trace ID: {request.trace_id}] "
+                    f"User: {request.user.username if request.user.is_authenticated else None} - "
+                    f"Request: {request.method} {request.get_full_path()} "
+                    f"({len(request.body) if request.body else 0} bytes): "
+                    f"{json.dumps(truncated_body)}"
+                )
+            except Exception as e:
+                logger.exception(
+                    f"[Trace ID: {request.trace_id}] An error occurred when parsing request: {e}"
+                )
+
         started_time = datetime.now()
         response = self.get_response(request)
         finished_time = datetime.now()
+
+        # Log all responses to v2 API endpoints
+        if settings.V2_API_LOGGING_ENABLED and request.path.startswith("/rest/v2/"):
+            try:
+                logger.info(
+                    f"[Trace ID: {request.trace_id}] "
+                    f"Response status: {response.status_code} ({len(response.content)} bytes)"
+                )
+            except Exception as e:
+                logger.exception(
+                    f"[Trace ID: {request.trace_id}] An error occurred when logging response: {e}"
+                )
 
         if request.resolver_match:
             endpoint = simplify_regex(request.resolver_match.route)

--- a/promgen/settings.py
+++ b/promgen/settings.py
@@ -230,6 +230,9 @@ AUTHENTICATION_BACKENDS = (
 # Maximum time to wait for all scraping operations to complete (in seconds)
 PROMGEN_EXPORTER_SCRAPE_TIMEOUT = env.int("PROMGEN_EXPORTER_SCRAPE_TIMEOUT", default=25)
 
+# v2 API settings
+V2_API_LOGGING_ENABLED = env.bool("V2_API_LOGGING_ENABLED", default=True)
+
 # Load overrides from PROMGEN to replace Django settings
 for k, v in PROMGEN.pop("django", {}).items():
     globals()[k] = v

--- a/promgen/util.py
+++ b/promgen/util.py
@@ -185,6 +185,52 @@ def fingerprint(body):
     return hashlib.sha1(buff.encode("utf8")).hexdigest()
 
 
+def truncate_json_fields(data, default_limits=128):
+    """
+    Recursively truncate fields in a JSON object.
+
+    Args:
+        data: The JSON to process.
+        default_limits (int): Default maximum length for fields not specified.
+
+    Returns:
+        A new JSON with truncated fields.
+    """
+    # A given field-length mapping for specifying the maximum lengths of fields in Promgen models
+    LOG_FIELD_LIMITS = {
+        "clause": 8192,  # Rule
+    }
+
+    if isinstance(data, list):
+        return [
+            truncate_json_fields(item, default_limits)
+            if isinstance(item, (dict, list))
+            else item[:default_limits]
+            + ("..." if isinstance(item, str) and len(item) > default_limits else "")
+            if isinstance(item, str)
+            else item
+            for item in data
+        ]
+
+    truncated_data = {}
+    if getattr(data, "items", None) is None:
+        return None
+    for field, value in data.items():
+        if isinstance(value, (dict, list)):
+            truncated_data[field] = truncate_json_fields(value, default_limits)
+        elif field in LOG_FIELD_LIMITS and isinstance(value, str):
+            truncated_data[field] = value[: LOG_FIELD_LIMITS[field]] + (
+                "..." if len(value) > LOG_FIELD_LIMITS[field] else ""
+            )
+        elif isinstance(value, str):
+            truncated_data[field] = value[:default_limits] + (
+                "..." if len(value) > default_limits else ""
+            )
+        else:
+            truncated_data[field] = value
+    return truncated_data
+
+
 # Comment wrappers to get the docstrings from the upstream functions
 get.__doc__ = requests.get.__doc__
 post.__doc__ = requests.post.__doc__


### PR DESCRIPTION
We have added a feature that allows the backend of Promgen to log request and response information for API V2. This is intended to display what has been done through these APIs. A unique trace ID is generated to link the request and response logs.

For **requests**, the method, path, and request body are logged. However, fields in the request body are truncated to avoid filling up the log. By default, the character limit is set to 128, but fields like "clause" are still logged in full as they are necessary. For **responses**, only the status and response content size are logged.

By default, this feature is disabled. It can be enabled by setting ENABLE_V2_API_LOGGING to True.