### PR TITLE
Add Custom Exception Handler for Django REST Framework

### DIFF
--- a/promgen/rest_v2.py
+++ b/promgen/rest_v2.py
@@ -16,13 +16,13 @@ from drf_spectacular.views import SpectacularAPIView
 from guardian.conf.settings import ANONYMOUS_USER_NAME
 from guardian.models import GroupObjectPermission
 from guardian.shortcuts import assign_perm, get_perms, remove_perm
-from rest_framework import mixins, pagination, routers, viewsets
+from rest_framework import exceptions, mixins, pagination, routers, viewsets
 from rest_framework.authtoken.models import Token
 from rest_framework.decorators import action
 from rest_framework.exceptions import MethodNotAllowed, NotFound, PermissionDenied, ValidationError
 from rest_framework.renderers import TemplateHTMLRenderer
 from rest_framework.response import Response
-from rest_framework.views import APIView
+from rest_framework.views import APIView, exception_handler
 
 import promgen.templatetags.promgen as promgen_templatetags
 from promgen import discovery, filters, models, permissions, serializers, signals, validators
@@ -65,6 +65,19 @@ class Router(routers.DefaultRouter):
         )
 
         return urls
+
+
+def custom_exception_handler(exc, context):
+    # Call REST framework's default exception handler first,
+    # to get the standard error response.
+    response = exception_handler(exc, context)
+
+    if response is None:
+        # If the response is None, an unexpected Python or Django exception occurs.
+        # We will return a server_error response.
+        return exceptions.server_error(context["request"])
+
+    return response
 
 
 class PromgenPagination(pagination.PageNumberPagination):

--- a/promgen/settings.py
+++ b/promgen/settings.py
@@ -199,6 +199,7 @@ REST_FRAMEWORK = {
     ),
     "DEFAULT_FILTER_BACKENDS": ("django_filters.rest_framework.DjangoFilterBackend",),
     "DEFAULT_SCHEMA_CLASS": "promgen.schemas.CustomSchema",
+    "EXCEPTION_HANDLER": "promgen.rest_v2.custom_exception_handler",
 }
 
 # If CELERY_BROKER_URL is set in our environment, then we configure celery as

--- a/promgen/tests/test_rest.py
+++ b/promgen/tests/test_rest.py
@@ -570,3 +570,30 @@ class RestAPITest(tests.PromgenTest):
         cases = tests.Data("cases", "test_rest_site.csv").csv()
         for case in cases:
             self._run_rest_test(case)
+
+    @override_settings(PROMGEN=tests.SETTINGS)
+    def test_exception_handler(self):
+        admin = User.objects.get(username="admin")
+        admin_token = Token.objects.filter(user=admin).first().key
+
+        # Expected exception (rest_framework.ValidationError) returns 400 HTTP code
+        # with the detail response.
+        response = self.client.patch(
+            reverse("api-v2:rule-detail", kwargs={"id": 1}),
+            data={"name": ""},
+            content_type="application/json",
+            HTTP_AUTHORIZATION=f"Token {admin_token}",
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json(), {"name": ["This field may not be blank."]})
+
+        # Unexpected exception (django.ValidationError) returns 500 HTTP code with
+        # the default response.
+        response = self.client.patch(
+            reverse("api-v2:rule-detail", kwargs={"id": 1}),
+            data={"clause": "This clause is not valid."},
+            content_type="application/json",
+            HTTP_AUTHORIZATION=f"Token {admin_token}",
+        )
+        self.assertEqual(response.status_code, 500)
+        self.assertEqual(response.json(), {"error": "Server Error (500)"})


### PR DESCRIPTION
By default, Django REST Framework (DRF) exception handler only intercepts known API exception (like ValidationError or PermissionDenied). If an unexpected Python exception occurs, it returns None, which causes Django to re-raise the error and return unexpected response. Therefore, we have added a custom exception handler to safely catch unexpected exceptions and return a standard 500 Server Error with a structured JSON response.